### PR TITLE
[WIP] Updating to On Demand

### DIFF
--- a/inst/include/RcppSimdJson/common.hpp
+++ b/inst/include/RcppSimdJson/common.hpp
@@ -26,7 +26,7 @@ static inline constexpr int64_t NA_INTEGER64 = LLONG_MIN;
 
 
 /**
- * @brief Typing arguments that decide how a simdjson::dom::element is ultimately returned to R.
+ * @brief Typing arguments that decide how a simdjson::ondemand::value is ultimately returned to R.
  */
 enum class rcpp_T : int {
     array  = 0, /**< recursive: individual elements will decide ultimate R type */
@@ -151,12 +151,12 @@ namespace deserialize {
 
 
 /**
- * @brief Simplify asimdjson::dom::element to an R object.
+ * @brief Simplify asimdjson::ondemand::value to an R object.
  *
  * @note Forward declaration. See inst/include/RcppSimdJson/deserialize/simplify.hpp.
  */
 template <Type_Policy type_policy, utils::Int64_R_Type int64_opt, Simplify_To simplify_to>
-inline auto simplify_element(simdjson::dom::element element,
+inline auto simplify_element(simdjson::ondemand::value value,
                              SEXP                   empty_array,
                              SEXP                   empty_object,
                              SEXP                   single_null) -> SEXP;

--- a/inst/include/RcppSimdJson/deserialize.hpp
+++ b/inst/include/RcppSimdJson/deserialize.hpp
@@ -422,7 +422,7 @@ inline auto deserialize(simdjson::ondemand::value parsed, const Parse_Opts& pars
 
 
 template <typename json_T, bool is_file>
-inline simdjson::simdjson_result<simdjson::ondemand::value> parse(simdjson::ondemand::parser& parser,
+inline simdjson::simdjson_result<simdjson::ondemand::document> parse(simdjson::ondemand::parser& parser,
                                                                const json_T&          json) {
     if constexpr (utils::resembles_vec_raw<json_T>()) {
         /* if `json` is a raw (unsigned char) vector, we can cheat */

--- a/inst/include/RcppSimdJson/deserialize.hpp
+++ b/inst/include/RcppSimdJson/deserialize.hpp
@@ -426,7 +426,7 @@ inline simdjson::simdjson_result<simdjson::ondemand::document> parse(simdjson::o
                                                                const json_T&          json) {
     if constexpr (utils::resembles_vec_raw<json_T>()) {
         /* if `json` is a raw (unsigned char) vector, we can cheat */
-        simdjson::padded_string content = simdjson::padded_string::padded_string(reinterpret_cast<const char*>(&(json[0])), json[0].length());
+        simdjson::padded_string content = simdjson::padded_string::(reinterpret_cast<const char*>(&(json[0])), json[0].size());
         return parser.iterate(content);
     }
 

--- a/inst/include/RcppSimdJson/deserialize.hpp
+++ b/inst/include/RcppSimdJson/deserialize.hpp
@@ -428,7 +428,7 @@ inline simdjson::simdjson_result<simdjson::ondemand::document> parse(simdjson::o
         /* if `json` is a raw (unsigned char) vector, we can cheat */
         simdjson::padded_string content = reinterpret_cast<const char*>(&(json[0]));
         return parser.iterate(
-            std::string_view(content, content.length());
+            std::string_view(content, content.length()));
     }
 
     if constexpr (utils::resembles_vec_chr<json_T>()) {

--- a/inst/include/RcppSimdJson/deserialize.hpp
+++ b/inst/include/RcppSimdJson/deserialize.hpp
@@ -426,7 +426,7 @@ inline simdjson::simdjson_result<simdjson::ondemand::document> parse(simdjson::o
                                                                const json_T&          json) {
     if constexpr (utils::resembles_vec_raw<json_T>()) {
         /* if `json` is a raw (unsigned char) vector, we can cheat */
-        simdjson::padded_string content = simdjson::padded_string(reinterpret_cast<const char*>( &(json[0]), json[0].size() ) );
+        simdjson::padded_string content = simdjson::padded_string(reinterpret_cast<const char*>( &(json[0]), std::size(json) );
         return parser.iterate(content);
     }
 

--- a/inst/include/RcppSimdJson/deserialize.hpp
+++ b/inst/include/RcppSimdJson/deserialize.hpp
@@ -443,7 +443,7 @@ inline simdjson::simdjson_result<simdjson::ondemand::document> parse(simdjson::o
                     parser, /* ... and decompress to a RawVector if so, then parse that */
                     utils::decompress(std::string(json), Rcpp::String(std::string(*file_type))));
             }
-            auto content = padded_string::load(json);
+            auto content = simdjson::padded_string::load(json);
             return parser.iterate(content); /* otherwise, load the file and iterate it*/
         } else {
             return parser.iterate(std::string_view(json)); /* if not file, just parse the string */

--- a/inst/include/RcppSimdJson/deserialize.hpp
+++ b/inst/include/RcppSimdJson/deserialize.hpp
@@ -39,10 +39,10 @@ struct Parse_Opts {
 
 
 /**
- * @brief Deserialize a parsed  simdjson::dom::element to R objects.
+ * @brief Deserialize a parsed  simdjson::ondemand::value to R objects.
  *
  *
- * @param element  simdjson::dom::element to deserialize.
+ * @param element  simdjson::ondemand::value to deserialize.
  *
  * @param empty_array R object to return when encountering an empty JSON array.
  *
@@ -58,7 +58,7 @@ struct Parse_Opts {
  *
  * @return The simplified R object ( SEXP ).
  */
-inline auto deserialize(simdjson::dom::element parsed, const Parse_Opts& parse_opts) -> SEXP {
+inline auto deserialize(simdjson::ondemand::value parsed, const Parse_Opts& parse_opts) -> SEXP {
     using Int64_R_Type = utils::Int64_R_Type;
 
     auto& [simplify_to, type_policy, int64_opt, empty_array, empty_object, single_null] =
@@ -422,11 +422,11 @@ inline auto deserialize(simdjson::dom::element parsed, const Parse_Opts& parse_o
 
 
 template <typename json_T, bool is_file>
-inline simdjson::simdjson_result<simdjson::dom::element> parse(simdjson::dom::parser& parser,
+inline simdjson::simdjson_result<simdjson::ondemand::value> parse(simdjson::ondemand::parser& parser,
                                                                const json_T&          json) {
     if constexpr (utils::resembles_vec_raw<json_T>()) {
         /* if `json` is a raw (unsigned char) vector, we can cheat */
-        return parser.parse(
+        return parser.iterate(
             std::string_view(reinterpret_cast<const char*>(&(json[0])), std::size(json)));
     }
 

--- a/inst/include/RcppSimdJson/deserialize.hpp
+++ b/inst/include/RcppSimdJson/deserialize.hpp
@@ -426,7 +426,7 @@ inline simdjson::simdjson_result<simdjson::ondemand::document> parse(simdjson::o
                                                                const json_T&          json) {
     if constexpr (utils::resembles_vec_raw<json_T>()) {
         /* if `json` is a raw (unsigned char) vector, we can cheat */
-        simdjson::padded_string content = simdjson::padded_string::(reinterpret_cast<const char*>(&(json[0])), json[0].size());
+        simdjson::padded_string content = simdjson::padded_string(reinterpret_cast<const char*>( &(json[0]), json[0].size() ) );
         return parser.iterate(content);
     }
 

--- a/inst/include/RcppSimdJson/deserialize.hpp
+++ b/inst/include/RcppSimdJson/deserialize.hpp
@@ -426,9 +426,8 @@ inline simdjson::simdjson_result<simdjson::ondemand::document> parse(simdjson::o
                                                                const json_T&          json) {
     if constexpr (utils::resembles_vec_raw<json_T>()) {
         /* if `json` is a raw (unsigned char) vector, we can cheat */
-        simdjson::padded_string content = reinterpret_cast<const char*>(&(json[0]));
-        return parser.iterate(
-            std::string_view(content, content.length()));
+        simdjson::padded_string content = simdjson::padded_string::padded_string(reinterpret_cast<const char*>(&(json[0])), json[0].length());
+        return parser.iterate(content);
     }
 
     if constexpr (utils::resembles_vec_chr<json_T>()) {

--- a/inst/include/RcppSimdJson/deserialize/Type_Doctor.hpp
+++ b/inst/include/RcppSimdJson/deserialize/Type_Doctor.hpp
@@ -74,12 +74,12 @@ inline Type_Doctor<type_policy, int64_opt>::Type_Doctor(simdjson::ondemand::arra
                 num_    = true;
                 break;
 
-            case utils::complete_json_type::boolean:
+            case simdjson::ondemand::json_type::boolean:
                 BOOL_ = true;
                 lgl_  = true;
                 break;
 
-            case utils::complete_json_type::null:
+            case simdjson::ondemand::json_type::null:
                 NULL_VALUE_ = true;
                 null_       = true;
                 break;
@@ -214,16 +214,16 @@ void Type_Doctor<type_policy, int64_opt>::add_element(simdjson::ondemand::value 
             break;
 
         case simdjson::ondemand::json_type::number:
-            DOUBLE_ = true;
-            dbl_    = true;
+            NUMBER_ = true;
+            num_    = true;
             break;
 
-        case utils::complete_json_type::boolean:
+        case simdjson::ondemand::json_type::boolean:
             BOOL_ = true;
             lgl_  = true;
             break;
 
-        case utils::complete_json_type::null:
+        case simdjson::ondemand::json_type::null:
             NULL_VALUE_ = true;
             null_       = true;
             break;
@@ -243,7 +243,7 @@ inline constexpr void Type_Doctor<type_policy, int64_opt>::update(
     this->STRING_ = this->STRING_ || type_doctor2.STRING_;
     this->chr_    = this->chr_ || type_doctor2.chr_;
 
-    this->NUM_ = this->NUM_ || type_doctor2.NUM_;
+    this->NUMBER_ = this->NUMBER_ || type_doctor2.NUMBER_;
     this->num_    = this->num_ || type_doctor2.num_;
 
     this->BOOL_ = this->BOOL_ || type_doctor2.BOOL_;

--- a/inst/include/RcppSimdJson/deserialize/Type_Doctor.hpp
+++ b/inst/include/RcppSimdJson/deserialize/Type_Doctor.hpp
@@ -187,7 +187,7 @@ inline constexpr simdjson::ondemand::json_type Type_Doctor<type_policy, int64_op
                ? json_type::array
                : OBJECT_ ? json_type::object
                          : STRING_ ? json_type::string
-                                             : NUM_ ? json_type::number
+                                             : NUMBER_ ? json_type::number
                                                                 : BOOL_ ? json_type::boolean
                                                                         : json_type::null;
 }

--- a/inst/include/RcppSimdJson/deserialize/Type_Doctor.hpp
+++ b/inst/include/RcppSimdJson/deserialize/Type_Doctor.hpp
@@ -40,48 +40,48 @@ class Type_Doctor {
 
   public:
     Type_Doctor() = default;
-    explicit Type_Doctor<type_policy, int64_opt>(simdjson::dom::array) noexcept;
+    explicit Type_Doctor<type_policy, int64_opt>(simdjson::ondemand::array) noexcept;
 
     [[nodiscard]] constexpr auto has_null() const noexcept -> bool { return null_; };
 
     [[nodiscard]] constexpr auto common_R_type() const noexcept -> rcpp_T;
     [[nodiscard]] constexpr auto common_element_type() const noexcept
-        -> simdjson::dom::element_type;
+        -> utils::complete_json_type;
 
     [[nodiscard]] constexpr auto is_homogeneous() const noexcept -> bool;
     [[nodiscard]] constexpr auto is_vectorizable() const noexcept -> bool;
 
-    auto add_element(simdjson::dom::element) noexcept -> void;
+    auto add_element(simdjson::ondemand::value) noexcept -> void;
 
     constexpr auto update(Type_Doctor<type_policy, int64_opt>&&) noexcept -> void;
 };
 
 
 template <Type_Policy type_policy, utils::Int64_R_Type int64_opt>
-inline Type_Doctor<type_policy, int64_opt>::Type_Doctor(simdjson::dom::array array) noexcept {
-    for (auto element : array) {
-        switch (element.type()) {
-            case simdjson::dom::element_type::ARRAY:
+inline Type_Doctor<type_policy, int64_opt>::Type_Doctor(simdjson::ondemand::array array) noexcept {
+    for (auto value : array) {
+        switch (utils::get_complete_json_type(value)) {
+            case utils::complete_json_type::array:
                 ARRAY_ = true;
                 array_ = true;
                 break;
 
-            case simdjson::dom::element_type::OBJECT:
+            case utils::complete_json_type::object:
                 OBJECT_ = true;
                 object_ = true;
                 break;
 
-            case simdjson::dom::element_type::STRING:
+            case utils::complete_json_type::string:
                 STRING_ = true;
                 chr_    = true;
                 break;
 
-            case simdjson::dom::element_type::DOUBLE:
+            case utils::complete_json_type::double:
                 DOUBLE_ = true;
                 dbl_    = true;
                 break;
 
-            case simdjson::dom::element_type::INT64: {
+            case utils::complete_json_type::int64: {
                 INT64_ = true;
                 if constexpr (int64_opt == utils::Int64_R_Type::Always) {
                     i64_ = true;
@@ -95,17 +95,17 @@ inline Type_Doctor<type_policy, int64_opt>::Type_Doctor(simdjson::dom::array arr
                 break;
             }
 
-            case simdjson::dom::element_type::BOOL:
+            case utils::complete_json_type::boolean:
                 BOOL_ = true;
                 lgl_  = true;
                 break;
 
-            case simdjson::dom::element_type::NULL_VALUE:
+            case utils::complete_json_type::null:
                 NULL_VALUE_ = true;
                 null_       = true;
                 break;
 
-            case simdjson::dom::element_type::UINT64:
+            case utils::complete_json_type:::
                 UINT64_ = true;
                 u64_    = true;
                 break;
@@ -240,47 +240,47 @@ inline constexpr auto Type_Doctor<type_policy, int64_opt>::is_vectorizable() con
 
 
 template <Type_Policy type_policy, utils::Int64_R_Type int64_opt>
-inline constexpr simdjson::dom::element_type
+inline constexpr utils::complete_json_type
 Type_Doctor<type_policy, int64_opt>::common_element_type() const noexcept {
 
-    using simdjson::dom::element_type;
+    using utils::complete_json_type;
 
     return ARRAY_
-               ? element_type::ARRAY
-               : OBJECT_ ? element_type::OBJECT
-                         : STRING_ ? element_type::STRING
-                                   : UINT64_ ? element_type::UINT64
-                                             : DOUBLE_ ? element_type::DOUBLE
-                                                       : INT64_ ? element_type::INT64
-                                                                : BOOL_ ? element_type::BOOL
-                                                                        : element_type::NULL_VALUE;
+               ? complete_json_type::array
+               : OBJECT_ ? complete_json_type::object
+                         : STRING_ ? complete_json_type::string
+                                   : UINT64_ ? complete_json_type::uint64
+                                             : DOUBLE_ ? complete_json_type::double
+                                                       : INT64_ ? complete_json_type::int64
+                                                                : BOOL_ ? complete_json_type::boolean
+                                                                        : complete_json_type::null;
 }
 
 
 template <Type_Policy type_policy, utils::Int64_R_Type int64_opt>
-void Type_Doctor<type_policy, int64_opt>::add_element(simdjson::dom::element element) noexcept {
-    switch (element.type()) {
-        case simdjson::dom::element_type::ARRAY:
+void Type_Doctor<type_policy, int64_opt>::add_element(simdjson::ondemand::value element) noexcept {
+    switch (utils::get_complete_json_type(value)) {
+        case utils::complete_json_type::array:
             ARRAY_ = true;
             array_ = true;
             break;
 
-        case simdjson::dom::element_type::OBJECT:
+        case utils::complete_json_type::object:
             OBJECT_ = true;
             object_ = true;
             break;
 
-        case simdjson::dom::element_type::STRING:
+        case utils::complete_json_type::string:
             STRING_ = true;
             chr_    = true;
             break;
 
-        case simdjson::dom::element_type::DOUBLE:
+        case utils::complete_json_type::double:
             DOUBLE_ = true;
             dbl_    = true;
             break;
 
-        case simdjson::dom::element_type::INT64: {
+        case utils::complete_json_type::int64: {
             INT64_ = true;
             if constexpr (int64_opt == utils::Int64_R_Type::Always) {
                 i64_ = true;
@@ -294,17 +294,17 @@ void Type_Doctor<type_policy, int64_opt>::add_element(simdjson::dom::element ele
             break;
         }
 
-        case simdjson::dom::element_type::BOOL:
+        case utils::complete_json_type::boolean:
             BOOL_ = true;
             lgl_  = true;
             break;
 
-        case simdjson::dom::element_type::NULL_VALUE:
+        case utils::complete_json_type::null:
             NULL_VALUE_ = true;
             null_       = true;
             break;
 
-        case simdjson::dom::element_type::UINT64:
+        case utils::complete_json_type::uint64:
             UINT64_ = true;
             u64_    = true;
             break;

--- a/inst/include/RcppSimdJson/deserialize/Type_Doctor.hpp
+++ b/inst/include/RcppSimdJson/deserialize/Type_Doctor.hpp
@@ -180,9 +180,8 @@ inline constexpr auto Type_Doctor<type_policy, int64_opt>::is_vectorizable() con
 
 
 template <Type_Policy type_policy, utils::Int64_R_Type int64_opt>
-inline constexpr simdjson::ondemand::json_type;
 Type_Doctor<type_policy, int64_opt>::common_element_type() const noexcept {
-
+    inline constexpr simdjson::ondemand::json_type;
     using simdjson::ondemand::json_type;
 
     return ARRAY_

--- a/inst/include/RcppSimdJson/deserialize/Type_Doctor.hpp
+++ b/inst/include/RcppSimdJson/deserialize/Type_Doctor.hpp
@@ -180,8 +180,7 @@ inline constexpr auto Type_Doctor<type_policy, int64_opt>::is_vectorizable() con
 
 
 template <Type_Policy type_policy, utils::Int64_R_Type int64_opt>
-Type_Doctor<type_policy, int64_opt>::common_element_type() const noexcept {
-    inline constexpr simdjson::ondemand::json_type;
+inline constexpr simdjson::ondemand::json_type Type_Doctor<type_policy, int64_opt>::common_element_type() const noexcept {
     using simdjson::ondemand::json_type;
 
     return ARRAY_

--- a/inst/include/RcppSimdJson/deserialize/Type_Doctor.hpp
+++ b/inst/include/RcppSimdJson/deserialize/Type_Doctor.hpp
@@ -189,7 +189,7 @@ Type_Doctor<type_policy, int64_opt>::common_element_type() const noexcept {
                ? json_type::array
                : OBJECT_ ? json_type::object
                          : STRING_ ? json_type::string
-                                             : DOUBLE_ ? json_type::number
+                                             : NUM_ ? json_type::number
                                                                 : BOOL_ ? json_type::boolean
                                                                         : json_type::null;
 }
@@ -243,23 +243,14 @@ inline constexpr void Type_Doctor<type_policy, int64_opt>::update(
     this->STRING_ = this->STRING_ || type_doctor2.STRING_;
     this->chr_    = this->chr_ || type_doctor2.chr_;
 
-    this->DOUBLE_ = this->DOUBLE_ || type_doctor2.DOUBLE_;
-    this->dbl_    = this->dbl_ || type_doctor2.dbl_;
-
-    this->INT64_ = this->INT64_ || type_doctor2.INT64_;
-    this->i64_   = this->i64_ || type_doctor2.i64_;
-    if constexpr (int64_opt != utils::Int64_R_Type::Always) {
-        this->i32_ = this->i32_ || type_doctor2.i32_;
-    }
+    this->NUM_ = this->NUM_ || type_doctor2.NUM_;
+    this->num_    = this->num_ || type_doctor2.num_;
 
     this->BOOL_ = this->BOOL_ || type_doctor2.BOOL_;
     this->lgl_  = this->lgl_ || type_doctor2.lgl_;
 
     this->NULL_VALUE_ = this->NULL_VALUE_ || type_doctor2.NULL_VALUE_;
     this->null_       = this->null_ || type_doctor2.null_;
-
-    this->UINT64_ = this->UINT64_ || type_doctor2.UINT64_;
-    this->u64_    = this->u64_ || type_doctor2.u64_;
 }
 
 

--- a/inst/include/RcppSimdJson/deserialize/dataframe.hpp
+++ b/inst/include/RcppSimdJson/deserialize/dataframe.hpp
@@ -142,8 +142,8 @@ inline auto build_col_integer64(simdjson::ondemand::array                      a
                 simdjson::ondemand::value value;
                 if(object.get_object().find_field_unordered(key).get(value) == simdjson::SUCCESS) {
                     switch (value.type()) {
-                        case simdjson::ondemand::json_type::double:
-                            stl_vec[i_row] = get_scalar<double, rcpp_T::i64, NO_NULLS>(value);
+                        case simdjson::ondemand::json_type::number:
+                            stl_vec[i_row] = get_scalar<double, rcpp_T::double, NO_NULLS>(value);
                             break;
 
                         case simdjson::ondemand::json_type::boolean:

--- a/inst/include/RcppSimdJson/deserialize/dataframe.hpp
+++ b/inst/include/RcppSimdJson/deserialize/dataframe.hpp
@@ -37,10 +37,10 @@ inline auto diagnose_data_frame(simdjson::ondemand::array array) noexcept(RCPPSI
         if(element.get(object) == simdjson::SUCCESS) {
             for (auto field : object) {
                 if (cols.schema.find(field.key()) == std::end(cols.schema)) {
-                    cols.schema[field.key()] = Column<type_policy, int64_opt>{
+                    cols.schema[std::string_view(field.key())] = Column<type_policy, int64_opt>{
                         col_index++, Type_Doctor<type_policy, int64_opt>()};
                 }
-                cols.schema[field.key()].schema.add_element(field.value());
+                cols.schema[std::string_view(field.key())].schema.add_element(field.value());
             }
         } else {
             return std::nullopt;

--- a/inst/include/RcppSimdJson/deserialize/dataframe.hpp
+++ b/inst/include/RcppSimdJson/deserialize/dataframe.hpp
@@ -36,11 +36,11 @@ inline auto diagnose_data_frame(simdjson::ondemand::array array) noexcept(RCPPSI
         simdjson::ondemand::object object;
         if(element.get(object) == simdjson::SUCCESS) {
             for (auto field : object) {
-                if (cols.schema.find(field.key()) == std::end(cols.schema)) {
-                    cols.schema[std::string_view(field.key())] = Column<type_policy, int64_opt>{
+                if (cols.schema.find(std::string_view(field.key().raw())) == std::end(cols.schema)) {
+                    cols.schema[std::string_view(field.key().raw())] = Column<type_policy, int64_opt>{
                         col_index++, Type_Doctor<type_policy, int64_opt>()};
                 }
-                cols.schema[std::string_view(field.key())].schema.add_element(field.value());
+                cols.schema[std::string_view(field.key().raw())].schema.add_element(field.value());
             }
         } else {
             return std::nullopt;

--- a/inst/include/RcppSimdJson/deserialize/dataframe.hpp
+++ b/inst/include/RcppSimdJson/deserialize/dataframe.hpp
@@ -105,16 +105,16 @@ inline auto build_col_integer64(simdjson::ondemand::array                      a
                                 const Type_Doctor<type_policy, int64_opt> type_doc) -> SEXP {
 
     if constexpr (int64_opt == utils::Int64_R_Type::Double) {
-        return build_col<REALSXP, int64_t, rcpp_T::dbl, type_policy>(array, key, type_doc);
+        return build_col<REALSXP, double, rcpp_T::dbl, type_policy>(array, key, type_doc);
     }
 
     if constexpr (int64_opt == utils::Int64_R_Type::String) {
-        return build_col<STRSXP, int64_t, rcpp_T::chr, type_policy>(array, key, type_doc);
+        return build_col<STRSXP, double, rcpp_T::chr, type_policy>(array, key, type_doc);
     }
 
     if constexpr (int64_opt == utils::Int64_R_Type::Integer64 ||
                   int64_opt == utils::Int64_R_Type::Always) {
-        auto stl_vec = std::vector<int64_t>(array.count_elements(), NA_INTEGER64);
+        auto stl_vec = std::vector<double>(array.count_elements(), NA_INTEGER64);
         auto i_row   = std::size_t(0ULL);
 
         if (type_doc.is_homogeneous()) {
@@ -141,12 +141,12 @@ inline auto build_col_integer64(simdjson::ondemand::array                      a
             for (auto object : array) {
                 simdjson::ondemand::value value;
                 if(object.get_object().find_field_unordered(key).get(value) == simdjson::SUCCESS) {
-                    switch (utils::get_complete_json_type(value)) {
-                        case utils::complete_json_type::int64:
-                            stl_vec[i_row] = get_scalar<int64_t, rcpp_T::i64, NO_NULLS>(value);
+                    switch (value.type()) {
+                        case simdjson::ondemand::json_type::double:
+                            stl_vec[i_row] = get_scalar<double, rcpp_T::i64, NO_NULLS>(value);
                             break;
 
-                        case utils::complete_json_type::boolean:
+                        case simdjson::ondemand::json_type::boolean:
                             stl_vec[i_row] = get_scalar<bool, rcpp_T::i64, NO_NULLS>(value);
                             break;
 

--- a/inst/include/RcppSimdJson/deserialize/dataframe.hpp
+++ b/inst/include/RcppSimdJson/deserialize/dataframe.hpp
@@ -114,7 +114,7 @@ inline auto build_col_integer64(simdjson::ondemand::array                      a
 
     if constexpr (int64_opt == utils::Int64_R_Type::Integer64 ||
                   int64_opt == utils::Int64_R_Type::Always) {
-        auto stl_vec = std::vector<double>(array.count_elements(), NA_INTEGER64);
+        auto stl_vec = std::vector<int64_t>(array.count_elements(), NA_INTEGER64);
         auto i_row   = std::size_t(0ULL);
 
         if (type_doc.is_homogeneous()) {
@@ -143,7 +143,7 @@ inline auto build_col_integer64(simdjson::ondemand::array                      a
                 if(object.get_object().find_field_unordered(key).get(value) == simdjson::SUCCESS) {
                     switch (value.type()) {
                         case simdjson::ondemand::json_type::number:
-                            stl_vec[i_row] = get_scalar<double, rcpp_T::double, NO_NULLS>(value);
+                            stl_vec[i_row] = get_scalar<int64_t, rcpp_T::i64, NO_NULLS>(value);
                             break;
 
                         case simdjson::ondemand::json_type::boolean:

--- a/inst/include/RcppSimdJson/deserialize/dataframe.hpp
+++ b/inst/include/RcppSimdJson/deserialize/dataframe.hpp
@@ -190,18 +190,6 @@ build_data_frame(simdjson::ondemand::array                                      
                 break;
             }
 
-            case rcpp_T::i64: {
-                out[col.index] =
-                    build_col_integer64<type_policy, int64_opt>(array, key, col.schema);
-                break;
-            }
-
-            case rcpp_T::i32: {
-                out[col.index] =
-                    build_col<INTSXP, int64_t, rcpp_T::i32, type_policy>(array, key, col.schema);
-                break;
-            }
-
             case rcpp_T::lgl: {
                 out[col.index] =
                     build_col<LGLSXP, bool, rcpp_T::lgl, type_policy>(array, key, col.schema);
@@ -210,12 +198,6 @@ build_data_frame(simdjson::ondemand::array                                      
 
             case rcpp_T::null: {
                 out[col.index] = Rcpp::LogicalVector(n_rows, NA_LOGICAL);
-                break;
-            }
-
-            case rcpp_T::u64: {
-                out[col.index] =
-                    build_col<STRSXP, uint64_t, rcpp_T::chr, type_policy>(array, key, col.schema);
                 break;
             }
 

--- a/inst/include/RcppSimdJson/deserialize/matrix.hpp
+++ b/inst/include/RcppSimdJson/deserialize/matrix.hpp
@@ -217,7 +217,7 @@ inline Rcpp::NumericVector build_matrix_integer64_mixed(simdjson::ondemand::arra
     for (simdjson::ondemand::array element : array) {
         std::size_t i(0ULL);
         for (auto sub_element : element) {
-            switch (element.type()) {
+            switch (sub_element.type()) {
                 case simdjson::ondemand::json_type::number:
                     stl_vec_int64[i + j] = get_scalar<double, rcpp_T::i64, NO_NULLS>(sub_element);
                     break;

--- a/inst/include/RcppSimdJson/deserialize/matrix.hpp
+++ b/inst/include/RcppSimdJson/deserialize/matrix.hpp
@@ -88,7 +88,7 @@ template <bool has_nulls>
 inline Rcpp::NumericVector build_matrix_integer64_typed(simdjson::ondemand::array array,
                                                         const std::size_t    n_cols) {
     const auto           n_rows(static_cast<R_xlen_t>(array.count_elements()));
-    std::vector<double> stl_vec_int64(n_rows * n_cols);
+    std::vector<int64_t> stl_vec_int64(n_rows * n_cols);
     std::size_t          j(0ULL);
 
 #ifdef RCPPSIMDJSON_IS_GCC_7
@@ -98,7 +98,7 @@ inline Rcpp::NumericVector build_matrix_integer64_typed(simdjson::ondemand::arra
         for (auto&& element : sub_array) {
             simdjson::ondemand::value val;
             if (element.get(val) == simdjson::SUCCESS) {
-                stl_vec_int64[i + j] = get_scalar<double, rcpp_T::i64, has_nulls>(val);
+                stl_vec_int64[i + j] = get_scalar<int64_t, rcpp_T::i64, has_nulls>(val);
                 i += n_rows;
             }
         }
@@ -112,7 +112,7 @@ inline Rcpp::NumericVector build_matrix_integer64_typed(simdjson::ondemand::arra
         for (auto element : sub_array) {
             simdjson::ondemand::value val;
             if (element.get(val) == simdjson::SUCCESS) {
-                stl_vec_int64[i + j] = get_scalar<double, rcpp_T::i64, has_nulls>(val);
+                stl_vec_int64[i + j] = get_scalar<int64_t, rcpp_T::i64, has_nulls>(val);
                 i += n_rows;
             }
         }

--- a/inst/include/RcppSimdJson/deserialize/matrix.hpp
+++ b/inst/include/RcppSimdJson/deserialize/matrix.hpp
@@ -56,8 +56,11 @@ inline Rcpp::Vector<RTYPE> build_matrix_typed(simdjson::ondemand::array array,
     for (simdjson::ondemand::array sub_array : array) {
         R_xlen_t i(0L);
         for (auto element : sub_array) {
-            out[i + j] = get_scalar<in_T, R_Type, has_nulls>(element);
-            i += n_rows;
+            simdjson::ondemand::value val;
+            if (element.get(val) == simdjson::SUCCESS) {
+                out[i + j] = get_scalar<in_T, R_Type, has_nulls>(val);
+                i += n_rows;
+            }
         }
         j++;
     }
@@ -67,8 +70,11 @@ inline Rcpp::Vector<RTYPE> build_matrix_typed(simdjson::ondemand::array array,
     for (simdjson::ondemand::array sub_array : array) {
         R_xlen_t i(0L);
         for (auto element : sub_array) {
-            out[i + j] = get_scalar<in_T, R_Type, has_nulls>(element);
-            i += n_rows;
+            simdjson::ondemand::value val;
+            if (element.get(val) == simdjson::SUCCESS) {
+                out[i + j] = get_scalar<in_T, R_Type, has_nulls>(val);
+                i += n_rows;
+            }
         }
         j++;
     }
@@ -90,8 +96,11 @@ inline Rcpp::NumericVector build_matrix_integer64_typed(simdjson::ondemand::arra
     for (simdjson::ondemand::array sub_array : array) {
         std::size_t i(0ULL);
         for (auto&& element : sub_array) {
-            stl_vec_int64[i + j] = get_scalar<double, rcpp_T::i64, has_nulls>(element);
-            i += n_rows;
+            simdjson::ondemand::value val;
+            if (element.get(val) == simdjson::SUCCESS) {
+                stl_vec_int64[i + j] = get_scalar<double, rcpp_T::i64, has_nulls>(val);
+                i += n_rows;
+            }
         }
         j++;
     }
@@ -101,8 +110,11 @@ inline Rcpp::NumericVector build_matrix_integer64_typed(simdjson::ondemand::arra
     for (simdjson::ondemand::array sub_array : array) {
         std::size_t i(0ULL);
         for (auto element : sub_array) {
-            stl_vec_int64[i + j] = get_scalar<double, rcpp_T::i64, has_nulls>(element);
-            i += n_rows;
+            simdjson::ondemand::value val;
+            if (element.get(val) == simdjson::SUCCESS) {
+                stl_vec_int64[i + j] = get_scalar<double, rcpp_T::i64, has_nulls>(val);
+                i += n_rows;
+            }
         }
         j++;
     }
@@ -163,8 +175,11 @@ inline SEXP build_matrix_mixed(simdjson::ondemand::array array, std::size_t n_co
     for (simdjson::ondemand::array sub_array : array) {
         R_xlen_t i(0L);
         for (auto&& element : sub_array) {
-            out[i + j] = get_scalar_dispatch<RTYPE>(element);
-            i += n_rows;
+            simdjson::ondemand::value val;
+            if (element.get(val) == simdjson::SUCCESS) {
+                out[i + j] = get_scalar_dispatch<RTYPE>(val);
+                i += n_rows;
+            }
         }
         j++;
     }
@@ -173,8 +188,11 @@ inline SEXP build_matrix_mixed(simdjson::ondemand::array array, std::size_t n_co
     for (simdjson::ondemand::array sub_array : array) {
         R_xlen_t i(0L);
         for (auto element : sub_array) {
-            out[i + j] = get_scalar_dispatch<RTYPE>(element);
-            i += n_rows;
+            simdjson::ondemand::value val;
+            if (element.get(val) == simdjson::SUCCESS) {
+                out[i + j] = get_scalar_dispatch<RTYPE>(val);
+                i += n_rows;
+            }
         }
         j++;
     }
@@ -195,19 +213,22 @@ inline Rcpp::NumericVector build_matrix_integer64_mixed(simdjson::ondemand::arra
     for (simdjson::ondemand::array sub_array : array) {
         std::size_t i(0ULL);
         for (auto&& element : sub_array) {
-            switch (element.type()) {
-                case simdjson::ondemand::json_type::number:
-                    stl_vec_int64[i + j] = get_scalar<double, rcpp_T::i64, NO_NULLS>(element);
-                    break;
+            simdjson::ondemand::value val;
+            if (element.get(val) == simdjson::SUCCESS) {
+                switch (element.type()) {
+                    case simdjson::ondemand::json_type::number:
+                        stl_vec_int64[i + j] = get_scalar<double, rcpp_T::i64, NO_NULLS>(val);
+                        break;
 
-                case simdjson::ondemand::json_type::boolean:
-                    stl_vec_int64[i + j] = get_scalar<bool, rcpp_T::i64, NO_NULLS>(element);
-                    break;
+                    case simdjson::ondemand::json_type::boolean:
+                        stl_vec_int64[i + j] = get_scalar<bool, rcpp_T::i64, NO_NULLS>(val);
+                        break;
 
-                default:
-                    stl_vec_int64[i + j] = NA_INTEGER64;
+                    default:
+                        stl_vec_int64[i + j] = NA_INTEGER64;
+                }
+                i += n_rows;
             }
-            i += n_rows;
         }
         j++;
     }
@@ -217,19 +238,22 @@ inline Rcpp::NumericVector build_matrix_integer64_mixed(simdjson::ondemand::arra
     for (simdjson::ondemand::array element : array) {
         std::size_t i(0ULL);
         for (auto sub_element : element) {
-            switch (sub_element.type()) {
-                case simdjson::ondemand::json_type::number:
-                    stl_vec_int64[i + j] = get_scalar<double, rcpp_T::i64, NO_NULLS>(sub_element);
-                    break;
+            simdjson::ondemand::value val;
+            if (sub_element.get(val) == simdjson::SUCCESS) {
+                switch (sub_element.type()) {
+                    case simdjson::ondemand::json_type::number:
+                        stl_vec_int64[i + j] = get_scalar<double, rcpp_T::i64, NO_NULLS>(val);
+                        break;
 
-                case simdjson::ondemand::json_type::boolean:
-                    stl_vec_int64[i + j] = get_scalar<bool, rcpp_T::i64, NO_NULLS>(sub_element);
-                    break;
+                    case simdjson::ondemand::json_type::boolean:
+                        stl_vec_int64[i + j] = get_scalar<bool, rcpp_T::i64, NO_NULLS>(val);
+                        break;
 
-                default:
-                    stl_vec_int64[i + j] = NA_INTEGER64;
+                    default:
+                        stl_vec_int64[i + j] = NA_INTEGER64;
+                }
+                i += n_rows;
             }
-            i += n_rows;
         }
         j++;
     }

--- a/inst/include/RcppSimdJson/deserialize/matrix.hpp
+++ b/inst/include/RcppSimdJson/deserialize/matrix.hpp
@@ -47,7 +47,7 @@ diagnose(simdjson::ondemand::array array) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
 template <int RTYPE, typename in_T, rcpp_T R_Type, bool has_nulls>
 inline Rcpp::Vector<RTYPE> build_matrix_typed(simdjson::ondemand::array array,
                                               const std::size_t    n_cols) {
-    const R_xlen_t      n_rows = static_cast<size_t>(array.count_elements());
+    const R_xlen_t      n_rows = static_cast<R_xlen_t>(array.count_elements());
     Rcpp::Matrix<RTYPE> out(n_rows, static_cast<R_xlen_t>(n_cols));
     R_xlen_t            j(0L);
 
@@ -81,7 +81,7 @@ inline Rcpp::Vector<RTYPE> build_matrix_typed(simdjson::ondemand::array array,
 template <bool has_nulls>
 inline Rcpp::NumericVector build_matrix_integer64_typed(simdjson::ondemand::array array,
                                                         const std::size_t    n_cols) {
-    const auto           n_rows(array.count_elements());
+    const auto           n_rows(static_cast<R_xlen_t>(array.count_elements()));
     std::vector<double> stl_vec_int64(n_rows * n_cols);
     std::size_t          j(0ULL);
 
@@ -130,7 +130,7 @@ inline SEXP dispatch_typed(simdjson::ondemand::array        array,
                        : build_matrix_typed<STRSXP, std::string, rcpp_T::chr, NO_NULLS>(array,
                                                                                         n_cols);
 
-        case simdjson::ondemand::json_type::number;
+        case simdjson::ondemand::json_type::number:
             return has_nulls
                        ? build_matrix_typed<REALSXP, double, rcpp_T::dbl, HAS_NULLS>(array, n_cols)
                        : build_matrix_typed<REALSXP, double, rcpp_T::dbl, NO_NULLS>(array, n_cols);
@@ -144,7 +144,7 @@ inline SEXP dispatch_typed(simdjson::ondemand::array        array,
 
             // # nocov start
         case simdjson::ondemand::json_type::null:
-            return Rcpp::LogicalVector(array.count_elements(), NA_LOGICAL);
+            return Rcpp::LogicalVector(static_cast<R_xlen_t>(array.count_elements()), NA_LOGICAL);
 
         default:
             return R_NilValue;
@@ -154,7 +154,7 @@ inline SEXP dispatch_typed(simdjson::ondemand::array        array,
 
 template <int RTYPE>
 inline SEXP build_matrix_mixed(simdjson::ondemand::array array, std::size_t n_cols) {
-    const R_xlen_t      n_rows(array.count_elements());
+    const R_xlen_t      n_rows(static_cast<R_xlen_t>(array.count_elements()));
     Rcpp::Matrix<RTYPE> out(n_rows, static_cast<R_xlen_t>(n_cols));
     R_xlen_t            j(0L);
 
@@ -186,7 +186,7 @@ inline SEXP build_matrix_mixed(simdjson::ondemand::array array, std::size_t n_co
 
 inline Rcpp::NumericVector build_matrix_integer64_mixed(simdjson::ondemand::array array,
                                                         std::size_t          n_cols) {
-    const auto           n_rows(array.count_elements());
+    const auto           n_rows(static_cast<R_xlen_t>(array.count_elements()));
     std::vector<double> stl_vec_int64(n_rows * n_cols);
     std::size_t          j(0ULL);
 
@@ -257,7 +257,7 @@ dispatch_mixed(simdjson::ondemand::array array, const rcpp_T R_Type, const std::
             return build_matrix_mixed<LGLSXP>(array, n_cols); // # nocov
 
         default: {
-            auto out = Rcpp::LogicalMatrix(array.count_elements(), n_cols);
+            auto out = Rcpp::LogicalMatrix(static_cast<R_xlen_t>(array.count_elements()), n_cols);
             out.fill(NA_LOGICAL);
             return out;
         }

--- a/inst/include/RcppSimdJson/deserialize/matrix.hpp
+++ b/inst/include/RcppSimdJson/deserialize/matrix.hpp
@@ -205,7 +205,7 @@ inline SEXP build_matrix_mixed(simdjson::ondemand::array array, std::size_t n_co
 inline Rcpp::NumericVector build_matrix_integer64_mixed(simdjson::ondemand::array array,
                                                         std::size_t          n_cols) {
     const auto           n_rows(static_cast<R_xlen_t>(array.count_elements()));
-    std::vector<double> stl_vec_int64(n_rows * n_cols);
+    std::vector<int64_t> stl_vec_int64(n_rows * n_cols);
     std::size_t          j(0ULL);
 
 #ifdef RCPPSIMDJSON_IS_GCC_7
@@ -217,7 +217,7 @@ inline Rcpp::NumericVector build_matrix_integer64_mixed(simdjson::ondemand::arra
             if (element.get(val) == simdjson::SUCCESS) {
                 switch (element.type()) {
                     case simdjson::ondemand::json_type::number:
-                        stl_vec_int64[i + j] = get_scalar<double, rcpp_T::i64, NO_NULLS>(val);
+                        stl_vec_int64[i + j] = get_scalar<int64_t, rcpp_T::i64, NO_NULLS>(val);
                         break;
 
                     case simdjson::ondemand::json_type::boolean:

--- a/inst/include/RcppSimdJson/deserialize/matrix.hpp
+++ b/inst/include/RcppSimdJson/deserialize/matrix.hpp
@@ -143,7 +143,7 @@ inline SEXP dispatch_typed(simdjson::ondemand::array        array,
 
 
             // # nocov start
-        case utils::complete_json_type::null:
+        case simdjson::ondemand::json_type::null:
             return Rcpp::LogicalVector(std::size(array), NA_LOGICAL);
 
         default:
@@ -253,29 +253,8 @@ dispatch_mixed(simdjson::ondemand::array array, const rcpp_T R_Type, const std::
         case rcpp_T::dbl:
             return build_matrix_mixed<REALSXP>(array, n_cols);
 
-        case rcpp_T::i64: {
-            if constexpr (int64_opt == utils::Int64_R_Type::Double) {
-                return build_matrix_mixed<REALSXP>(array, n_cols);
-            }
-
-            if constexpr (int64_opt == utils::Int64_R_Type::String) {
-                return build_matrix_mixed<STRSXP>(array, n_cols);
-            }
-
-            if constexpr (int64_opt == utils::Int64_R_Type::Integer64 ||
-                          int64_opt == utils::Int64_R_Type::Always) {
-                return build_matrix_integer64_mixed(array, n_cols);
-            }
-        }
-
-        case rcpp_T::i32:
-            return build_matrix_mixed<INTSXP>(array, n_cols);
-
         case rcpp_T::lgl:                                     // # nocov
             return build_matrix_mixed<LGLSXP>(array, n_cols); // # nocov
-
-        case rcpp_T::u64:
-            return build_matrix_mixed<STRSXP>(array, n_cols);
 
         default: {
             auto out = Rcpp::LogicalMatrix(std::size(array), n_cols);

--- a/inst/include/RcppSimdJson/deserialize/matrix.hpp
+++ b/inst/include/RcppSimdJson/deserialize/matrix.hpp
@@ -144,7 +144,7 @@ inline SEXP dispatch_typed(simdjson::ondemand::array        array,
 
             // # nocov start
         case simdjson::ondemand::json_type::null:
-            return Rcpp::LogicalVector(std::size(array), NA_LOGICAL);
+            return Rcpp::LogicalVector(array.count_elements(), NA_LOGICAL);
 
         default:
             return R_NilValue;
@@ -186,7 +186,7 @@ inline SEXP build_matrix_mixed(simdjson::ondemand::array array, std::size_t n_co
 
 inline Rcpp::NumericVector build_matrix_integer64_mixed(simdjson::ondemand::array array,
                                                         std::size_t          n_cols) {
-    const auto           n_rows(std::size(array));
+    const auto           n_rows(array.count_elements());
     std::vector<double> stl_vec_int64(n_rows * n_cols);
     std::size_t          j(0ULL);
 
@@ -195,12 +195,12 @@ inline Rcpp::NumericVector build_matrix_integer64_mixed(simdjson::ondemand::arra
     for (simdjson::ondemand::array sub_array : array) {
         std::size_t i(0ULL);
         for (auto&& element : sub_array) {
-            switch (utils::get_complete_type(element)) {
-                case utils::complete_json_type::int64:
+            switch (element.type()) {
+                case simdjson::ondemand::json_type::number:
                     stl_vec_int64[i + j] = get_scalar<double, rcpp_T::i64, NO_NULLS>(element);
                     break;
 
-                case utils::complete_json_type::boolean:
+                case simdjson::ondemand::json_type::boolean:
                     stl_vec_int64[i + j] = get_scalar<bool, rcpp_T::i64, NO_NULLS>(element);
                     break;
 
@@ -217,12 +217,12 @@ inline Rcpp::NumericVector build_matrix_integer64_mixed(simdjson::ondemand::arra
     for (simdjson::ondemand::array element : array) {
         std::size_t i(0ULL);
         for (auto sub_element : element) {
-            switch (utils.get_complete_type(element)) {
-                case utils::complete_json_type::int64:
+            switch (element.type()) {
+                case simdjson::ondemand::json_type::number:
                     stl_vec_int64[i + j] = get_scalar<double, rcpp_T::i64, NO_NULLS>(sub_element);
                     break;
 
-                case utils::complete_json_type::boolean:
+                case simdjson::ondemand::json_type::boolean:
                     stl_vec_int64[i + j] = get_scalar<bool, rcpp_T::i64, NO_NULLS>(sub_element);
                     break;
 
@@ -257,7 +257,7 @@ dispatch_mixed(simdjson::ondemand::array array, const rcpp_T R_Type, const std::
             return build_matrix_mixed<LGLSXP>(array, n_cols); // # nocov
 
         default: {
-            auto out = Rcpp::LogicalMatrix(std::size(array), n_cols);
+            auto out = Rcpp::LogicalMatrix(array.count_elements(), n_cols);
             out.fill(NA_LOGICAL);
             return out;
         }

--- a/inst/include/RcppSimdJson/deserialize/matrix.hpp
+++ b/inst/include/RcppSimdJson/deserialize/matrix.hpp
@@ -47,7 +47,7 @@ diagnose(simdjson::ondemand::array array) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
 template <int RTYPE, typename in_T, rcpp_T R_Type, bool has_nulls>
 inline Rcpp::Vector<RTYPE> build_matrix_typed(simdjson::ondemand::array array,
                                               const std::size_t    n_cols) {
-    const R_xlen_t      n_rows = array.count_elements();
+    const R_xlen_t      n_rows = static_cast<size_t>(array.count_elements());
     Rcpp::Matrix<RTYPE> out(n_rows, static_cast<R_xlen_t>(n_cols));
     R_xlen_t            j(0L);
 

--- a/inst/include/RcppSimdJson/deserialize/scalar.hpp
+++ b/inst/include/RcppSimdJson/deserialize/scalar.hpp
@@ -145,7 +145,7 @@ get_scalar_dispatch<REALSXP>(simdjson::ondemand::value element) noexcept(RCPPSIM
             return get_scalar<double, rcpp_T::dbl, NO_NULLS>(element);
 
         case simdjson::ondemand::json_type::boolean:
-            return get_scalar<bool, rcpp_T::dbl, NO_NULLS>(element);
+            return get_scalar<bool, rcpp_T::dbl, HAS_NULLS>(element);
 
         default:
             return NA_REAL;

--- a/inst/include/RcppSimdJson/deserialize/scalar.hpp
+++ b/inst/include/RcppSimdJson/deserialize/scalar.hpp
@@ -21,7 +21,7 @@ template <typename in_T, rcpp_T R_Type>
 inline auto get_scalar_(simdjson::ondemand::value) noexcept(noxcpt<R_Type>());
 
 template <typename in_T, rcpp_T R_Type, bool has_null>
-inline simdjson::simdjson_result<simdjson::ondemand::value> get_scalar(simdjson::ondemand::value element) noexcept(noxcpt<R_Type>()) {
+inline auto get_scalar(simdjson::ondemand::value element) noexcept(noxcpt<R_Type>()) {
     if constexpr (has_null) {
         return element.is_null() ? na_val<R_Type>() : get_scalar_<in_T, R_Type>(element);
     } else {
@@ -34,63 +34,63 @@ inline simdjson::simdjson_result<simdjson::ondemand::value> get_scalar(simdjson:
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) {
+get_scalar_<bool, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) const {
     return bool(element) ? Rcpp::String("TRUE") : Rcpp::String("FALSE");
 }
 // return double
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()) {
+get_scalar_<bool, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()) const{
     return bool(element) ? 1.0 : 0.0;
 }
 // return int64_t
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::i64>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i64>()) {
+get_scalar_<bool, rcpp_T::i64>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i64>()) const{
     return bool(element) ? static_cast<int64_t>(1LL) : static_cast<int64_t>(0LL);
 }
 // return int
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::i32>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i32>()) {
+get_scalar_<bool, rcpp_T::i32>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i32>()) const{
     return bool(element) ? 1 : 0;
 }
 // return "bool"
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::lgl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::lgl>()) {
+get_scalar_<bool, rcpp_T::lgl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::lgl>()) const{
     return bool(element);
 }
 // int64_t =========================================================================================
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) {
+get_scalar_<int64_t, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) const{
     return Rcpp::String(std::to_string(int64_t(element)));
 }
 // return double
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()) {
+get_scalar_<int64_t, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()) const{
     return double(element);
 }
 // return int64_t
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::i64>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i64>()) {
+get_scalar_<int64_t, rcpp_T::i64>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i64>()) const{
     return int64_t(element);
 }
 // return int
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::i32>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i32>()) {
+get_scalar_<int64_t, rcpp_T::i32>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i32>()) const{
     return static_cast<int>(int64_t(element));
 }
 // double ==========================================================================================
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<double, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) {
+get_scalar_<double, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) const{
     auto out = std::to_string(double(element));
     out.erase(out.find_last_not_of('0') + 2, std::string::npos);
     return Rcpp::String(out);
@@ -98,21 +98,21 @@ get_scalar_<double, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(nox
 // return double
 template <>
 inline auto
-get_scalar_<double, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()) {
+get_scalar_<double, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()) const{
     return double(element);
 }
 // std::string (really std::string_view) ===========================================================
 // return Rcpp::String
 template <>
 inline auto get_scalar_<std::string, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(
-    noxcpt<rcpp_T::chr>()) {
+    noxcpt<rcpp_T::chr>()) const{
     return Rcpp::String(std::string(std::string_view(element)));
 }
 // uint64_t ========================================================================================
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<uint64_t, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) {
+get_scalar_<uint64_t, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) const{
     return Rcpp::String(std::to_string(uint64_t(element)));
 }
 // dispatchers =====================================================================================
@@ -120,7 +120,7 @@ template <int RTYPE>
 inline auto get_scalar_dispatch(simdjson::ondemand::value) noexcept(noxcpt<RTYPE>());
 
 template <>
-inline auto get_scalar_dispatch<STRSXP>(simdjson::ondemand::value element) noexcept(false) {
+inline auto get_scalar_dispatch<STRSXP>(simdjson::ondemand::value element) noexcept(false) const{
     switch (element.type()) {
         case simdjson::ondemand::json_type::string:
             return get_scalar<std::string, rcpp_T::chr, NO_NULLS>(element);

--- a/inst/include/RcppSimdJson/deserialize/scalar.hpp
+++ b/inst/include/RcppSimdJson/deserialize/scalar.hpp
@@ -161,7 +161,7 @@ get_scalar_dispatch<INTSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMD
             return get_scalar<double, rcpp_T::i32, NO_NULLS>(element);
 
         case simdjson::ondemand::json_type::boolean:
-            return get_scalar<bool, rcpp_T::i32, HAS_NULLS>(element);
+            return get_scalar<bool, rcpp_T::i32, NO_NULLS>(element);
 
         default:
             return NA_INTEGER;

--- a/inst/include/RcppSimdJson/deserialize/scalar.hpp
+++ b/inst/include/RcppSimdJson/deserialize/scalar.hpp
@@ -21,7 +21,7 @@ template <typename in_T, rcpp_T R_Type>
 inline auto get_scalar_(simdjson::ondemand::value) noexcept(noxcpt<R_Type>());
 
 template <typename in_T, rcpp_T R_Type, bool has_null>
-inline auto get_scalar(simdjson::ondemand::value element) const noexcept(noxcpt<R_Type>()) {
+inline auto get_scalar(simdjson::ondemand::value element) noexcept(noxcpt<R_Type>()) {
     if constexpr (has_null) {
         return element.is_null() ? na_val<R_Type>() : get_scalar_<in_T, R_Type>(element);
     } else {
@@ -34,63 +34,63 @@ inline auto get_scalar(simdjson::ondemand::value element) const noexcept(noxcpt<
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::chr>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::chr>()) {
+get_scalar_<bool, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) {
     return bool(element) ? Rcpp::String("TRUE") : Rcpp::String("FALSE");
 }
 // return double
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::dbl>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::dbl>()){
+get_scalar_<bool, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()){
     return bool(element) ? 1.0 : 0.0;
 }
 // return int64_t
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::i64>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::i64>()){
+get_scalar_<bool, rcpp_T::i64>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i64>()){
     return bool(element) ? static_cast<int64_t>(1LL) : static_cast<int64_t>(0LL);
 }
 // return int
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::i32>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::i32>()) {
+get_scalar_<bool, rcpp_T::i32>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i32>()) {
     return bool(element) ? 1 : 0;
 }
 // return "bool"
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::lgl>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::lgl>()) {
+get_scalar_<bool, rcpp_T::lgl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::lgl>()) {
     return bool(element);
 }
 // int64_t =========================================================================================
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::chr>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::chr>()) {
+get_scalar_<int64_t, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) {
     return Rcpp::String(std::to_string(int64_t(element)));
 }
 // return double
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::dbl>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::dbl>()) {
+get_scalar_<int64_t, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()) {
     return double(element);
 }
 // return int64_t
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::i64>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::i64>()) {
+get_scalar_<int64_t, rcpp_T::i64>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i64>()) {
     return int64_t(element);
 }
 // return int
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::i32>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::i32>()) {
+get_scalar_<int64_t, rcpp_T::i32>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i32>()) {
     return static_cast<int>(int64_t(element));
 }
 // double ==========================================================================================
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<double, rcpp_T::chr>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::chr>()) {
+get_scalar_<double, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) {
     auto out = std::to_string(double(element));
     out.erase(out.find_last_not_of('0') + 2, std::string::npos);
     return Rcpp::String(out);
@@ -98,13 +98,13 @@ get_scalar_<double, rcpp_T::chr>(simdjson::ondemand::value element) const noexce
 // return double
 template <>
 inline auto
-get_scalar_<double, rcpp_T::dbl>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::dbl>()) {
+get_scalar_<double, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()) {
     return double(element);
 }
 // std::string (really std::string_view) ===========================================================
 // return Rcpp::String
 template <>
-inline auto get_scalar_<std::string, rcpp_T::chr>(simdjson::ondemand::value element) const noexcept(
+inline auto get_scalar_<std::string, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(
     noxcpt<rcpp_T::chr>()) {
     return Rcpp::String(std::string(std::string_view(element)));
 }
@@ -112,7 +112,7 @@ inline auto get_scalar_<std::string, rcpp_T::chr>(simdjson::ondemand::value elem
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<uint64_t, rcpp_T::chr>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::chr>()) {
+get_scalar_<uint64_t, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) {
     return Rcpp::String(std::to_string(uint64_t(element)));
 }
 // dispatchers =====================================================================================
@@ -120,7 +120,7 @@ template <int RTYPE>
 inline auto get_scalar_dispatch(simdjson::ondemand::value) noexcept(noxcpt<RTYPE>());
 
 template <>
-inline auto get_scalar_dispatch<STRSXP>(simdjson::ondemand::value element) const noexcept(false) {
+inline auto get_scalar_dispatch<STRSXP>(simdjson::ondemand::value element) noexcept(false) {
     switch (element.type()) {
         case simdjson::ondemand::json_type::string:
             return get_scalar<std::string, rcpp_T::chr, NO_NULLS>(element);
@@ -139,7 +139,7 @@ inline auto get_scalar_dispatch<STRSXP>(simdjson::ondemand::value element) const
 
 template <>
 inline auto
-get_scalar_dispatch<REALSXP>(simdjson::ondemand::value element) const noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
+get_scalar_dispatch<REALSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
     switch (element.type()) {
         case simdjson::ondemand::json_type::number:
             return get_scalar<double, rcpp_T::dbl, NO_NULLS>(element);
@@ -155,7 +155,7 @@ get_scalar_dispatch<REALSXP>(simdjson::ondemand::value element) const noexcept(R
 
 template <>
 inline auto
-get_scalar_dispatch<INTSXP>(simdjson::ondemand::value element) const noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
+get_scalar_dispatch<INTSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
     switch (element.type()) {
         case simdjson::ondemand::json_type::number:
             return get_scalar<double, rcpp_T::i32, NO_NULLS>(element);
@@ -171,7 +171,7 @@ get_scalar_dispatch<INTSXP>(simdjson::ondemand::value element) const noexcept(RC
 // # nocov start
 template <>
 inline auto
-get_scalar_dispatch<LGLSXP>(simdjson::ondemand::value element) const noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
+get_scalar_dispatch<LGLSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
     switch (element.type()) {
         case simdjson::ondemand::json_type::boolean:
             return get_scalar<bool, rcpp_T::i32, NO_NULLS>(element);

--- a/inst/include/RcppSimdJson/deserialize/scalar.hpp
+++ b/inst/include/RcppSimdJson/deserialize/scalar.hpp
@@ -21,7 +21,7 @@ template <typename in_T, rcpp_T R_Type>
 inline auto get_scalar_(simdjson::ondemand::value) noexcept(noxcpt<R_Type>());
 
 template <typename in_T, rcpp_T R_Type, bool has_null>
-inline auto get_scalar(simdjson::ondemand::value element) noexcept(noxcpt<R_Type>()) {
+inline auto get_scalar(simdjson::ondemand::value element) const noexcept(noxcpt<R_Type>()) {
     if constexpr (has_null) {
         return element.is_null() ? na_val<R_Type>() : get_scalar_<in_T, R_Type>(element);
     } else {
@@ -34,63 +34,63 @@ inline auto get_scalar(simdjson::ondemand::value element) noexcept(noxcpt<R_Type
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) const {
+get_scalar_<bool, rcpp_T::chr>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::chr>()) {
     return bool(element) ? Rcpp::String("TRUE") : Rcpp::String("FALSE");
 }
 // return double
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()) const{
+get_scalar_<bool, rcpp_T::dbl>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::dbl>()){
     return bool(element) ? 1.0 : 0.0;
 }
 // return int64_t
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::i64>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i64>()) const{
+get_scalar_<bool, rcpp_T::i64>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::i64>()){
     return bool(element) ? static_cast<int64_t>(1LL) : static_cast<int64_t>(0LL);
 }
 // return int
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::i32>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i32>()) const{
+get_scalar_<bool, rcpp_T::i32>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::i32>()) {
     return bool(element) ? 1 : 0;
 }
 // return "bool"
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::lgl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::lgl>()) const{
+get_scalar_<bool, rcpp_T::lgl>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::lgl>()) {
     return bool(element);
 }
 // int64_t =========================================================================================
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) const{
+get_scalar_<int64_t, rcpp_T::chr>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::chr>()) {
     return Rcpp::String(std::to_string(int64_t(element)));
 }
 // return double
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()) const{
+get_scalar_<int64_t, rcpp_T::dbl>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::dbl>()) {
     return double(element);
 }
 // return int64_t
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::i64>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i64>()) const{
+get_scalar_<int64_t, rcpp_T::i64>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::i64>()) {
     return int64_t(element);
 }
 // return int
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::i32>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i32>()) const{
+get_scalar_<int64_t, rcpp_T::i32>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::i32>()) {
     return static_cast<int>(int64_t(element));
 }
 // double ==========================================================================================
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<double, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) const{
+get_scalar_<double, rcpp_T::chr>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::chr>()) {
     auto out = std::to_string(double(element));
     out.erase(out.find_last_not_of('0') + 2, std::string::npos);
     return Rcpp::String(out);
@@ -98,21 +98,21 @@ get_scalar_<double, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(nox
 // return double
 template <>
 inline auto
-get_scalar_<double, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()) const{
+get_scalar_<double, rcpp_T::dbl>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::dbl>()) {
     return double(element);
 }
 // std::string (really std::string_view) ===========================================================
 // return Rcpp::String
 template <>
-inline auto get_scalar_<std::string, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(
-    noxcpt<rcpp_T::chr>()) const{
+inline auto get_scalar_<std::string, rcpp_T::chr>(simdjson::ondemand::value element) const noexcept(
+    noxcpt<rcpp_T::chr>()) {
     return Rcpp::String(std::string(std::string_view(element)));
 }
 // uint64_t ========================================================================================
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<uint64_t, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) const{
+get_scalar_<uint64_t, rcpp_T::chr>(simdjson::ondemand::value element) const noexcept(noxcpt<rcpp_T::chr>()) {
     return Rcpp::String(std::to_string(uint64_t(element)));
 }
 // dispatchers =====================================================================================
@@ -120,7 +120,7 @@ template <int RTYPE>
 inline auto get_scalar_dispatch(simdjson::ondemand::value) noexcept(noxcpt<RTYPE>());
 
 template <>
-inline auto get_scalar_dispatch<STRSXP>(simdjson::ondemand::value element) noexcept(false) const{
+inline auto get_scalar_dispatch<STRSXP>(simdjson::ondemand::value element) const noexcept(false) {
     switch (element.type()) {
         case simdjson::ondemand::json_type::string:
             return get_scalar<std::string, rcpp_T::chr, NO_NULLS>(element);
@@ -139,7 +139,7 @@ inline auto get_scalar_dispatch<STRSXP>(simdjson::ondemand::value element) noexc
 
 template <>
 inline auto
-get_scalar_dispatch<REALSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
+get_scalar_dispatch<REALSXP>(simdjson::ondemand::value element) const noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
     switch (element.type()) {
         case simdjson::ondemand::json_type::number:
             return get_scalar<double, rcpp_T::dbl, NO_NULLS>(element);
@@ -155,7 +155,7 @@ get_scalar_dispatch<REALSXP>(simdjson::ondemand::value element) noexcept(RCPPSIM
 
 template <>
 inline auto
-get_scalar_dispatch<INTSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
+get_scalar_dispatch<INTSXP>(simdjson::ondemand::value element) const noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
     switch (element.type()) {
         case simdjson::ondemand::json_type::number:
             return get_scalar<double, rcpp_T::i32, NO_NULLS>(element);
@@ -171,7 +171,7 @@ get_scalar_dispatch<INTSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMD
 // # nocov start
 template <>
 inline auto
-get_scalar_dispatch<LGLSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
+get_scalar_dispatch<LGLSXP>(simdjson::ondemand::value element) const noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
     switch (element.type()) {
         case simdjson::ondemand::json_type::boolean:
             return get_scalar<bool, rcpp_T::i32, NO_NULLS>(element);

--- a/inst/include/RcppSimdJson/deserialize/scalar.hpp
+++ b/inst/include/RcppSimdJson/deserialize/scalar.hpp
@@ -21,7 +21,7 @@ template <typename in_T, rcpp_T R_Type>
 inline auto get_scalar_(simdjson::ondemand::value) noexcept(noxcpt<R_Type>());
 
 template <typename in_T, rcpp_T R_Type, bool has_null>
-inline auto get_scalar(simdjson::ondemand::value element) noexcept(noxcpt<R_Type>()) {
+inline simdjson::simdjson_result<simdjson::ondemand::value> get_scalar(simdjson::ondemand::value element) noexcept(noxcpt<R_Type>()) {
     if constexpr (has_null) {
         return element.is_null() ? na_val<R_Type>() : get_scalar_<in_T, R_Type>(element);
     } else {

--- a/inst/include/RcppSimdJson/deserialize/scalar.hpp
+++ b/inst/include/RcppSimdJson/deserialize/scalar.hpp
@@ -121,21 +121,15 @@ inline auto get_scalar_dispatch(simdjson::ondemand::value) noexcept(noxcpt<RTYPE
 
 template <>
 inline auto get_scalar_dispatch<STRSXP>(simdjson::ondemand::value element) noexcept(false) {
-    switch (utils::get_complete_json_type(element)) {
-        case utils::complete_json_type::string:
+    switch (element.type()) {
+        case simdjson::ondemand::json_type::string:
             return get_scalar<std::string, rcpp_T::chr, NO_NULLS>(element);
 
-        case utils::complete_json_type::double:
+        case simdjson::ondemand::json_type::number:
             return get_scalar<double, rcpp_T::chr, NO_NULLS>(element);
 
-        case utils::complete_json_type::int64:
-            return get_scalar<int64_t, rcpp_T::chr, NO_NULLS>(element);
-
-        case utils::complete_json_type::boolean:
+        case simdjson::ondemand::json_type::boolean:
             return get_scalar<bool, rcpp_T::chr, NO_NULLS>(element);
-
-        case utils::complete_json_type::uint64:
-            return get_scalar<uint64_t, rcpp_T::chr, NO_NULLS>(element);
 
         default:
             return Rcpp::String(NA_STRING);
@@ -146,14 +140,11 @@ inline auto get_scalar_dispatch<STRSXP>(simdjson::ondemand::value element) noexc
 template <>
 inline auto
 get_scalar_dispatch<REALSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
-    switch (utils::get_complete_json_type(element)) {
-        case utils::complete_json_type::double:
+    switch (element.type()) {
+        case simdjson::ondemand::json_type::::number:
             return get_scalar<double, rcpp_T::dbl, NO_NULLS>(element);
 
-        case utils::complete_json_type::int64:
-            return get_scalar<int64_t, rcpp_T::dbl, NO_NULLS>(element);
-
-        case utils::complete_json_type::boolean:
+        case simdjson::ondemand::json_type::::boolean:
             return get_scalar<bool, rcpp_T::dbl, NO_NULLS>(element);
 
         default:
@@ -165,11 +156,11 @@ get_scalar_dispatch<REALSXP>(simdjson::ondemand::value element) noexcept(RCPPSIM
 template <>
 inline auto
 get_scalar_dispatch<INTSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
-    switch (utils::get_complete_json_type(element)) {
-        case utils::complete_json_type::int64:
-            return get_scalar<int64_t, rcpp_T::i32, NO_NULLS>(element);
+    switch (element.type()) {
+        case simdjson::ondemand::json_type::number:
+            return get_scalar<double, rcpp_T::i32, NO_NULLS>(element);
 
-        case utils::complete_json_type::boolean:
+        case simdjson::ondemand::json_type::boolean:
             return get_scalar<bool, rcpp_T::i32, HAS_NULLS>(element);
 
         default:
@@ -181,8 +172,8 @@ get_scalar_dispatch<INTSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMD
 template <>
 inline auto
 get_scalar_dispatch<LGLSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
-    switch (utils::get_complete_json_type(element)) {
-        case utils::complete_json_type::boolean:
+    switch (element.type()) {
+        case simdjson::ondemand::json_type::boolean:
             return get_scalar<bool, rcpp_T::i32, NO_NULLS>(element);
 
         default:

--- a/inst/include/RcppSimdJson/deserialize/scalar.hpp
+++ b/inst/include/RcppSimdJson/deserialize/scalar.hpp
@@ -141,10 +141,10 @@ template <>
 inline auto
 get_scalar_dispatch<REALSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
     switch (element.type()) {
-        case simdjson::ondemand::json_type::::number:
+        case simdjson::ondemand::json_type::number:
             return get_scalar<double, rcpp_T::dbl, NO_NULLS>(element);
 
-        case simdjson::ondemand::json_type::::boolean:
+        case simdjson::ondemand::json_type::boolean:
             return get_scalar<bool, rcpp_T::dbl, NO_NULLS>(element);
 
         default:

--- a/inst/include/RcppSimdJson/deserialize/scalar.hpp
+++ b/inst/include/RcppSimdJson/deserialize/scalar.hpp
@@ -18,10 +18,10 @@ static inline constexpr bool NO_NULLS = false;
 
 
 template <typename in_T, rcpp_T R_Type>
-inline auto get_scalar_(simdjson::dom::element) noexcept(noxcpt<R_Type>());
+inline auto get_scalar_(simdjson::ondemand::value) noexcept(noxcpt<R_Type>());
 
 template <typename in_T, rcpp_T R_Type, bool has_null>
-inline auto get_scalar(simdjson::dom::element element) noexcept(noxcpt<R_Type>()) {
+inline auto get_scalar(simdjson::ondemand::value element) noexcept(noxcpt<R_Type>()) {
     if constexpr (has_null) {
         return element.is_null() ? na_val<R_Type>() : get_scalar_<in_T, R_Type>(element);
     } else {
@@ -34,63 +34,63 @@ inline auto get_scalar(simdjson::dom::element element) noexcept(noxcpt<R_Type>()
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::chr>(simdjson::dom::element element) noexcept(noxcpt<rcpp_T::chr>()) {
+get_scalar_<bool, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) {
     return bool(element) ? Rcpp::String("TRUE") : Rcpp::String("FALSE");
 }
 // return double
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::dbl>(simdjson::dom::element element) noexcept(noxcpt<rcpp_T::dbl>()) {
+get_scalar_<bool, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()) {
     return bool(element) ? 1.0 : 0.0;
 }
 // return int64_t
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::i64>(simdjson::dom::element element) noexcept(noxcpt<rcpp_T::i64>()) {
+get_scalar_<bool, rcpp_T::i64>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i64>()) {
     return bool(element) ? static_cast<int64_t>(1LL) : static_cast<int64_t>(0LL);
 }
 // return int
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::i32>(simdjson::dom::element element) noexcept(noxcpt<rcpp_T::i32>()) {
+get_scalar_<bool, rcpp_T::i32>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i32>()) {
     return bool(element) ? 1 : 0;
 }
 // return "bool"
 template <>
 inline auto
-get_scalar_<bool, rcpp_T::lgl>(simdjson::dom::element element) noexcept(noxcpt<rcpp_T::lgl>()) {
+get_scalar_<bool, rcpp_T::lgl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::lgl>()) {
     return bool(element);
 }
 // int64_t =========================================================================================
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::chr>(simdjson::dom::element element) noexcept(noxcpt<rcpp_T::chr>()) {
+get_scalar_<int64_t, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) {
     return Rcpp::String(std::to_string(int64_t(element)));
 }
 // return double
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::dbl>(simdjson::dom::element element) noexcept(noxcpt<rcpp_T::dbl>()) {
+get_scalar_<int64_t, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()) {
     return double(element);
 }
 // return int64_t
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::i64>(simdjson::dom::element element) noexcept(noxcpt<rcpp_T::i64>()) {
+get_scalar_<int64_t, rcpp_T::i64>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i64>()) {
     return int64_t(element);
 }
 // return int
 template <>
 inline auto
-get_scalar_<int64_t, rcpp_T::i32>(simdjson::dom::element element) noexcept(noxcpt<rcpp_T::i32>()) {
+get_scalar_<int64_t, rcpp_T::i32>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::i32>()) {
     return static_cast<int>(int64_t(element));
 }
 // double ==========================================================================================
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<double, rcpp_T::chr>(simdjson::dom::element element) noexcept(noxcpt<rcpp_T::chr>()) {
+get_scalar_<double, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) {
     auto out = std::to_string(double(element));
     out.erase(out.find_last_not_of('0') + 2, std::string::npos);
     return Rcpp::String(out);
@@ -98,13 +98,13 @@ get_scalar_<double, rcpp_T::chr>(simdjson::dom::element element) noexcept(noxcpt
 // return double
 template <>
 inline auto
-get_scalar_<double, rcpp_T::dbl>(simdjson::dom::element element) noexcept(noxcpt<rcpp_T::dbl>()) {
+get_scalar_<double, rcpp_T::dbl>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::dbl>()) {
     return double(element);
 }
 // std::string (really std::string_view) ===========================================================
 // return Rcpp::String
 template <>
-inline auto get_scalar_<std::string, rcpp_T::chr>(simdjson::dom::element element) noexcept(
+inline auto get_scalar_<std::string, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(
     noxcpt<rcpp_T::chr>()) {
     return Rcpp::String(std::string(std::string_view(element)));
 }
@@ -112,29 +112,29 @@ inline auto get_scalar_<std::string, rcpp_T::chr>(simdjson::dom::element element
 // return Rcpp::String
 template <>
 inline auto
-get_scalar_<uint64_t, rcpp_T::chr>(simdjson::dom::element element) noexcept(noxcpt<rcpp_T::chr>()) {
+get_scalar_<uint64_t, rcpp_T::chr>(simdjson::ondemand::value element) noexcept(noxcpt<rcpp_T::chr>()) {
     return Rcpp::String(std::to_string(uint64_t(element)));
 }
 // dispatchers =====================================================================================
 template <int RTYPE>
-inline auto get_scalar_dispatch(simdjson::dom::element) noexcept(noxcpt<RTYPE>());
+inline auto get_scalar_dispatch(simdjson::ondemand::value) noexcept(noxcpt<RTYPE>());
 
 template <>
-inline auto get_scalar_dispatch<STRSXP>(simdjson::dom::element element) noexcept(false) {
-    switch (element.type()) {
-        case simdjson::dom::element_type::STRING:
+inline auto get_scalar_dispatch<STRSXP>(simdjson::ondemand::value element) noexcept(false) {
+    switch (utils::get_complete_json_type(element)) {
+        case utils::complete_json_type::string:
             return get_scalar<std::string, rcpp_T::chr, NO_NULLS>(element);
 
-        case simdjson::dom::element_type::DOUBLE:
+        case utils::complete_json_type::double:
             return get_scalar<double, rcpp_T::chr, NO_NULLS>(element);
 
-        case simdjson::dom::element_type::INT64:
+        case utils::complete_json_type::int64:
             return get_scalar<int64_t, rcpp_T::chr, NO_NULLS>(element);
 
-        case simdjson::dom::element_type::BOOL:
+        case utils::complete_json_type::boolean:
             return get_scalar<bool, rcpp_T::chr, NO_NULLS>(element);
 
-        case simdjson::dom::element_type::UINT64:
+        case utils::complete_json_type::uint64:
             return get_scalar<uint64_t, rcpp_T::chr, NO_NULLS>(element);
 
         default:
@@ -145,15 +145,15 @@ inline auto get_scalar_dispatch<STRSXP>(simdjson::dom::element element) noexcept
 
 template <>
 inline auto
-get_scalar_dispatch<REALSXP>(simdjson::dom::element element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
+get_scalar_dispatch<REALSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
     switch (element.type()) {
-        case simdjson::dom::element_type::DOUBLE:
+        case utils::complete_json_type::double:
             return get_scalar<double, rcpp_T::dbl, NO_NULLS>(element);
 
-        case simdjson::dom::element_type::INT64:
+        case utils::complete_json_type::int64:
             return get_scalar<int64_t, rcpp_T::dbl, NO_NULLS>(element);
 
-        case simdjson::dom::element_type::BOOL:
+        case utils::complete_json_type::boolean:
             return get_scalar<bool, rcpp_T::dbl, NO_NULLS>(element);
 
         default:
@@ -164,12 +164,12 @@ get_scalar_dispatch<REALSXP>(simdjson::dom::element element) noexcept(RCPPSIMDJS
 
 template <>
 inline auto
-get_scalar_dispatch<INTSXP>(simdjson::dom::element element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
+get_scalar_dispatch<INTSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
     switch (element.type()) {
-        case simdjson::dom::element_type::INT64:
+        case utils::complete_json_type::int64:
             return get_scalar<int64_t, rcpp_T::i32, NO_NULLS>(element);
 
-        case simdjson::dom::element_type::BOOL:
+        case utils::complete_json_type::boolean:
             return get_scalar<bool, rcpp_T::i32, HAS_NULLS>(element);
 
         default:
@@ -180,9 +180,9 @@ get_scalar_dispatch<INTSXP>(simdjson::dom::element element) noexcept(RCPPSIMDJSO
 // # nocov start
 template <>
 inline auto
-get_scalar_dispatch<LGLSXP>(simdjson::dom::element element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
+get_scalar_dispatch<LGLSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
     switch (element.type()) {
-        case simdjson::dom::element_type::BOOL:
+        case utils::complete_json_type::boolean:
             return get_scalar<bool, rcpp_T::i32, NO_NULLS>(element);
 
         default:

--- a/inst/include/RcppSimdJson/deserialize/scalar.hpp
+++ b/inst/include/RcppSimdJson/deserialize/scalar.hpp
@@ -146,7 +146,7 @@ inline auto get_scalar_dispatch<STRSXP>(simdjson::ondemand::value element) noexc
 template <>
 inline auto
 get_scalar_dispatch<REALSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
-    switch (element.type()) {
+    switch (utils::get_complete_json_type(element)) {
         case utils::complete_json_type::double:
             return get_scalar<double, rcpp_T::dbl, NO_NULLS>(element);
 
@@ -165,7 +165,7 @@ get_scalar_dispatch<REALSXP>(simdjson::ondemand::value element) noexcept(RCPPSIM
 template <>
 inline auto
 get_scalar_dispatch<INTSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
-    switch (element.type()) {
+    switch (utils::get_complete_json_type(element)) {
         case utils::complete_json_type::int64:
             return get_scalar<int64_t, rcpp_T::i32, NO_NULLS>(element);
 
@@ -181,7 +181,7 @@ get_scalar_dispatch<INTSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMD
 template <>
 inline auto
 get_scalar_dispatch<LGLSXP>(simdjson::ondemand::value element) noexcept(RCPPSIMDJSON_NO_EXCEPTIONS) {
-    switch (element.type()) {
+    switch (utils::get_complete_json_type(element)) {
         case utils::complete_json_type::boolean:
             return get_scalar<bool, rcpp_T::i32, NO_NULLS>(element);
 

--- a/inst/include/RcppSimdJson/deserialize/simplify.hpp
+++ b/inst/include/RcppSimdJson/deserialize/simplify.hpp
@@ -125,7 +125,7 @@ inline SEXP simplify_object(simdjson::ondemand::object object,
     for (auto field : object) {
         out[i] = simplify_element<type_policy, int64_opt, simplify_to>(
             field.value(), empty_array, empty_object, single_null);
-        out_names[i++] = Rcpp::String(std::string_view(field.key().raw()));
+        out_names[i++] = Rcpp::String(std::string( std::string_view( field.key().raw() ) ));
     }
 
     out.attr("names") = out_names;
@@ -161,7 +161,7 @@ template <Type_Policy type_policy, utils::Int64_R_Type int64_opt, Simplify_To si
 inline SEXP simplify_element(simdjson::ondemand::value value,
                              SEXP                   empty_array,
                              SEXP                   empty_object,
-                             SEXP                   single_null) const {
+                             SEXP                   single_null) noexcept(false) {
     switch (value.type()) {
         case simdjson::ondemand::json_type::array:
             return dispatch_simplify_array<type_policy, int64_opt, simplify_to>(

--- a/inst/include/RcppSimdJson/deserialize/simplify.hpp
+++ b/inst/include/RcppSimdJson/deserialize/simplify.hpp
@@ -119,10 +119,10 @@ inline SEXP simplify_object(const simdjson::ondemand::object object,
     Rcpp::CharacterVector out_names(n);
 
     auto i = R_xlen_t(0L);
-    for (auto [key, value] : object) {
+    for (auto field : object) {
         out[i] = simplify_element<type_policy, int64_opt, simplify_to>(
-            value, empty_array, empty_object, single_null);
-        out_names[i++] = Rcpp::String(std::string(key));
+            field.value(), empty_array, empty_object, single_null);
+        out_names[i++] = Rcpp::String(std::string(field.key()));
     }
 
     out.attr("names") = out_names;

--- a/inst/include/RcppSimdJson/deserialize/simplify.hpp
+++ b/inst/include/RcppSimdJson/deserialize/simplify.hpp
@@ -112,7 +112,7 @@ inline SEXP simplify_object(simdjson::ondemand::object object,
                             SEXP                        single_null) {
     size_t n{0};
     for (auto field : object) {
-        size_t++;
+        n++;
     }
     if (n == 0) {
         return empty_object;
@@ -162,7 +162,7 @@ inline SEXP simplify_element(simdjson::ondemand::value value,
                              SEXP                   empty_array,
                              SEXP                   empty_object,
                              SEXP                   single_null) {
-    switch (value.type()) const {
+    switch (value.type()) {
         case simdjson::ondemand::json_type::array:
             return dispatch_simplify_array<type_policy, int64_opt, simplify_to>(
                 simdjson::ondemand::array(value), empty_array, empty_object, single_null);

--- a/inst/include/RcppSimdJson/deserialize/simplify.hpp
+++ b/inst/include/RcppSimdJson/deserialize/simplify.hpp
@@ -159,20 +159,17 @@ inline SEXP simplify_element(simdjson::ondemand::value value,
                              SEXP                   empty_array,
                              SEXP                   empty_object,
                              SEXP                   single_null) {
-    switch (utils::get_complete_json_type(value)) {
-        case utils::complete_json::type::array:
+    switch (value.type()) {
+        case simdjson::ondemand::json_type::array:
             return dispatch_simplify_array<type_policy, int64_opt, simplify_to>(
                 simdjson::ondemand::array(value), empty_array, empty_object, single_null);
 
-        case utils::complete_json::type::object:
+        case simdjson::ondemand::json_type::object:
             return simplify_object<type_policy, int64_opt, simplify_to>(
                 simdjson::ondemand::object(value), empty_array, empty_object, single_null);
 
-        case utils::complete_json_type::double:
+        case simdjson::ondemand::json_type::number:
             return Rcpp::wrap(double(value));
-
-        case utils::complete_json_type::int64:
-            return utils::resolve_int64<int64_opt>(int64_t(value));
 
         case utils::complete_json_type::boolean:
             return Rcpp::wrap(bool(value));
@@ -182,9 +179,6 @@ inline SEXP simplify_element(simdjson::ondemand::value value,
 
         case utils::complete_json::type::null:
             return single_null;
-
-        case utils::complete_json_type::uint64:
-            return Rcpp::wrap(std::to_string(uint64_t(value)));
     }
 
     return R_NilValue; // # nocov

--- a/inst/include/RcppSimdJson/deserialize/simplify.hpp
+++ b/inst/include/RcppSimdJson/deserialize/simplify.hpp
@@ -20,8 +20,11 @@ simplify_list(simdjson::ondemand::array array, SEXP empty_array, SEXP empty_obje
     Rcpp::List out(array.count_elements());
     auto i = R_xlen_t(0);
     for (auto value : array) {
-        out[i++] = simplify_element<type_policy, int64_opt, simplify_to>(
-            value, empty_array, empty_object, single_null);
+        simdjson::ondemand::value val;
+        if (value.get(val) == simdjson::SUCCESS) {
+            out[i++] = simplify_element<type_policy, int64_opt, simplify_to>(
+                val, empty_array, empty_object, single_null);
+        }
     }
     return out;
 }

--- a/inst/include/RcppSimdJson/deserialize/simplify.hpp
+++ b/inst/include/RcppSimdJson/deserialize/simplify.hpp
@@ -111,7 +111,7 @@ inline SEXP simplify_object(const simdjson::ondemand::object object,
                             SEXP                        empty_object,
                             SEXP                        single_null) {
     size_t n{0};
-    for (auto field : object) {
+    for (auto field : const object) {
         size_t++;
     }
     if (n == 0) {
@@ -122,7 +122,7 @@ inline SEXP simplify_object(const simdjson::ondemand::object object,
     Rcpp::CharacterVector out_names(n);
 
     auto i = R_xlen_t(0L);
-    for (auto field : object) {
+    for (auto field : const object) {
         out[i] = simplify_element<type_policy, int64_opt, simplify_to>(
             field.value(), empty_array, empty_object, single_null);
         out_names[i++] = Rcpp::String(std::string(field.key()));

--- a/inst/include/RcppSimdJson/deserialize/simplify.hpp
+++ b/inst/include/RcppSimdJson/deserialize/simplify.hpp
@@ -17,7 +17,7 @@ namespace deserialize {
 template <Type_Policy type_policy, utils::Int64_R_Type int64_opt, Simplify_To simplify_to>
 inline SEXP
 simplify_list(simdjson::ondemand::array array, SEXP empty_array, SEXP empty_object, SEXP single_null) {
-    Rcpp::List out(r_length(array));
+    Rcpp::List out(array.count_elements());
     auto i = R_xlen_t(0);
     for (auto value : array) {
         out[i++] = simplify_element<type_policy, int64_opt, simplify_to>(
@@ -79,7 +79,7 @@ inline SEXP dispatch_simplify_array(simdjson::ondemand::array array,
                                     SEXP                 empty_array,
                                     SEXP                 empty_object,
                                     SEXP                 single_null) {
-    if (std::size(array) == 0) {
+    if (array.count_elements() == 0) {
         return empty_array;
     }
 
@@ -110,7 +110,10 @@ inline SEXP simplify_object(const simdjson::ondemand::object object,
                             SEXP                        empty_array,
                             SEXP                        empty_object,
                             SEXP                        single_null) {
-    const auto n = r_length(object);
+    size_t n{0};
+    for (auto field : object) {
+        size_t++;
+    }
     if (n == 0) {
         return empty_object;
     }
@@ -171,13 +174,13 @@ inline SEXP simplify_element(simdjson::ondemand::value value,
         case simdjson::ondemand::json_type::number:
             return Rcpp::wrap(double(value));
 
-        case utils::complete_json_type::boolean:
+        case simdjson::ondemand::json_type::boolean:
             return Rcpp::wrap(bool(value));
 
-        case utils::complete_json::type::string:
+        case simdjson::ondemand::json_type::string:
             return Rcpp::wrap(Rcpp::String(std::string(std::string_view(value))));
 
-        case utils::complete_json::type::null:
+        case simdjson::ondemand::json_type::null:
             return single_null;
     }
 

--- a/inst/include/RcppSimdJson/deserialize/simplify.hpp
+++ b/inst/include/RcppSimdJson/deserialize/simplify.hpp
@@ -106,12 +106,12 @@ inline SEXP dispatch_simplify_array(simdjson::ondemand::array array,
 
 
 template <Type_Policy type_policy, utils::Int64_R_Type int64_opt, Simplify_To simplify_to>
-inline SEXP simplify_object(const simdjson::ondemand::object object,
+inline SEXP simplify_object(simdjson::ondemand::object object,
                             SEXP                        empty_array,
                             SEXP                        empty_object,
                             SEXP                        single_null) {
     size_t n{0};
-    for (auto field : const object) {
+    for (auto field : object) {
         size_t++;
     }
     if (n == 0) {
@@ -122,7 +122,7 @@ inline SEXP simplify_object(const simdjson::ondemand::object object,
     Rcpp::CharacterVector out_names(n);
 
     auto i = R_xlen_t(0L);
-    for (auto field : const object) {
+    for (auto field : object) {
         out[i] = simplify_element<type_policy, int64_opt, simplify_to>(
             field.value(), empty_array, empty_object, single_null);
         out_names[i++] = Rcpp::String(std::string(field.key()));
@@ -162,7 +162,7 @@ inline SEXP simplify_element(simdjson::ondemand::value value,
                              SEXP                   empty_array,
                              SEXP                   empty_object,
                              SEXP                   single_null) {
-    switch (value.type()) {
+    switch (value.type()) const {
         case simdjson::ondemand::json_type::array:
             return dispatch_simplify_array<type_policy, int64_opt, simplify_to>(
                 simdjson::ondemand::array(value), empty_array, empty_object, single_null);

--- a/inst/include/RcppSimdJson/deserialize/simplify.hpp
+++ b/inst/include/RcppSimdJson/deserialize/simplify.hpp
@@ -161,7 +161,7 @@ template <Type_Policy type_policy, utils::Int64_R_Type int64_opt, Simplify_To si
 inline SEXP simplify_element(simdjson::ondemand::value value,
                              SEXP                   empty_array,
                              SEXP                   empty_object,
-                             SEXP                   single_null) {
+                             SEXP                   single_null) const {
     switch (value.type()) {
         case simdjson::ondemand::json_type::array:
             return dispatch_simplify_array<type_policy, int64_opt, simplify_to>(

--- a/inst/include/RcppSimdJson/deserialize/simplify.hpp
+++ b/inst/include/RcppSimdJson/deserialize/simplify.hpp
@@ -125,7 +125,7 @@ inline SEXP simplify_object(simdjson::ondemand::object object,
     for (auto field : object) {
         out[i] = simplify_element<type_policy, int64_opt, simplify_to>(
             field.value(), empty_array, empty_object, single_null);
-        out_names[i++] = Rcpp::String(std::string_view(field.key()));
+        out_names[i++] = Rcpp::String(std::string_view(field.key().raw()));
     }
 
     out.attr("names") = out_names;

--- a/inst/include/RcppSimdJson/deserialize/simplify.hpp
+++ b/inst/include/RcppSimdJson/deserialize/simplify.hpp
@@ -125,7 +125,7 @@ inline SEXP simplify_object(simdjson::ondemand::object object,
     for (auto field : object) {
         out[i] = simplify_element<type_policy, int64_opt, simplify_to>(
             field.value(), empty_array, empty_object, single_null);
-        out_names[i++] = Rcpp::String(std::string(field.key()));
+        out_names[i++] = Rcpp::String(std::string_view(field.key()));
     }
 
     out.attr("names") = out_names;

--- a/inst/include/RcppSimdJson/deserialize/vector.hpp
+++ b/inst/include/RcppSimdJson/deserialize/vector.hpp
@@ -92,16 +92,16 @@ inline Rcpp::Vector<RTYPE> build_vector_mixed(simdjson::ondemand::array array) {
 
 
 inline Rcpp::Vector<REALSXP> build_vector_integer64_mixed(simdjson::ondemand::array array) {
-    std::vector<int64_t> stl_vec_int64(array.count_elements());
+    std::vector<double> stl_vec_int64(array.count_elements());
     std::size_t          i(0ULL);
 
     for (auto element : array) {
-        switch (utils::get_complete_json_type(element)) {
-            case utils::complete_json_type::int64:
-                stl_vec_int64[i++] = get_scalar<int64_t, rcpp_T::i64, HAS_NULLS>(element);
+        switch (element.type()) {
+            case simdjson::ondemand::json_type::number:
+                stl_vec_int64[i++] = get_scalar<double, rcpp_T::i64, HAS_NULLS>(element);
                 break;
 
-            case utils::complete_json_type::boolean:
+            case simdjson::ondemand::json_type::boolean:
                 stl_vec_int64[i++] = get_scalar<bool, rcpp_T::i64, HAS_NULLS>(element);
                 break;
 

--- a/inst/include/RcppSimdJson/deserialize/vector.hpp
+++ b/inst/include/RcppSimdJson/deserialize/vector.hpp
@@ -13,7 +13,10 @@ inline Rcpp::Vector<RTYPE> build_vector_typed(simdjson::ondemand::array array) {
     Rcpp::Vector<RTYPE> out(array.count_elements());
     R_xlen_t            i(0L);
     for (auto element : array) {
-        out[i++] = get_scalar<in_T, R_Type, has_nulls>(element);
+        simdjson::ondemand::value val;
+        if (element.get(val) == simdjson::SUCCESS) {
+            out[i++] = get_scalar<in_T, R_Type, has_nulls>(val);
+        }
     }
     return out;
 }
@@ -24,7 +27,10 @@ inline Rcpp::Vector<REALSXP> build_vector_integer64_typed(simdjson::ondemand::ar
     std::vector<int64_t> stl_vec_int64(array.count_elements());
     std::size_t          i(0ULL);
     for (auto element : array) {
-        stl_vec_int64[i++] = get_scalar<int64_t, rcpp_T::i64, has_nulls>(element);
+        simdjson::ondemand::value val;
+        if (element.get(val) == simdjson::SUCCESS) {
+            stl_vec_int64[i++] = get_scalar<int64_t, rcpp_T::i64, has_nulls>(val);
+        }
     }
     return utils::as_integer64(stl_vec_int64);
 }
@@ -85,7 +91,10 @@ inline Rcpp::Vector<RTYPE> build_vector_mixed(simdjson::ondemand::array array) {
     Rcpp::Vector<RTYPE> out(array.count_elements());
     R_xlen_t            i(0L);
     for (auto element : array) {
-        out[i++] = get_scalar_dispatch<RTYPE>(element);
+        simdjson::ondemand::value val;
+        if (element.get(val) == simdjson::SUCCESS) {
+            out[i++] = get_scalar_dispatch<RTYPE>(val);
+        }
     }
     return out;
 }
@@ -96,18 +105,21 @@ inline Rcpp::Vector<REALSXP> build_vector_integer64_mixed(simdjson::ondemand::ar
     std::size_t          i(0ULL);
 
     for (auto element : array) {
-        switch (element.type()) {
-            case simdjson::ondemand::json_type::number:
-                stl_vec_int64[i++] = get_scalar<double, rcpp_T::i64, HAS_NULLS>(element);
-                break;
+        simdjson::ondemand::value val;
+        if (element.get(val) == simdjson::SUCCESS) {
+            switch (element.type()) {
+                case simdjson::ondemand::json_type::number:
+                    stl_vec_int64[i++] = get_scalar<double, rcpp_T::i64, HAS_NULLS>(val);
+                    break;
 
-            case simdjson::ondemand::json_type::boolean:
-                stl_vec_int64[i++] = get_scalar<bool, rcpp_T::i64, HAS_NULLS>(element);
-                break;
+                case simdjson::ondemand::json_type::boolean:
+                    stl_vec_int64[i++] = get_scalar<bool, rcpp_T::i64, HAS_NULLS>(val);
+                    break;
 
-            default:
-                stl_vec_int64[i++] = NA_INTEGER64;
-                break;
+                default:
+                    stl_vec_int64[i++] = NA_INTEGER64;
+                    break;
+            }
         }
     }
 

--- a/inst/include/RcppSimdJson/deserialize/vector.hpp
+++ b/inst/include/RcppSimdJson/deserialize/vector.hpp
@@ -9,8 +9,8 @@ namespace vector {
 
 
 template <int RTYPE, typename in_T, rcpp_T R_Type, bool has_nulls>
-inline Rcpp::Vector<RTYPE> build_vector_typed(simdjson::dom::array array) {
-    Rcpp::Vector<RTYPE> out(std::size(array));
+inline Rcpp::Vector<RTYPE> build_vector_typed(simdjson::ondemand::array array) {
+    Rcpp::Vector<RTYPE> out(array.count_elements());
     R_xlen_t            i(0L);
     for (auto element : array) {
         out[i++] = get_scalar<in_T, R_Type, has_nulls>(element);
@@ -20,8 +20,8 @@ inline Rcpp::Vector<RTYPE> build_vector_typed(simdjson::dom::array array) {
 
 
 template <bool has_nulls>
-inline Rcpp::Vector<REALSXP> build_vector_integer64_typed(simdjson::dom::array array) {
-    std::vector<int64_t> stl_vec_int64(std::size(array));
+inline Rcpp::Vector<REALSXP> build_vector_integer64_typed(simdjson::ondemand::array array) {
+    std::vector<int64_t> stl_vec_int64(array.count_elements());
     std::size_t          i(0ULL);
     for (auto element : array) {
         stl_vec_int64[i++] = get_scalar<int64_t, rcpp_T::i64, has_nulls>(element);
@@ -31,7 +31,7 @@ inline Rcpp::Vector<REALSXP> build_vector_integer64_typed(simdjson::dom::array a
 
 
 template <utils::Int64_R_Type int64_opt>
-inline SEXP dispatch_typed(simdjson::dom::array array, const rcpp_T R_Type, const bool has_nulls) {
+inline SEXP dispatch_typed(simdjson::ondemand::array array, const rcpp_T R_Type, const bool has_nulls) {
     switch (R_Type) {
         case rcpp_T::chr:
             return has_nulls
@@ -75,14 +75,14 @@ inline SEXP dispatch_typed(simdjson::dom::array array, const rcpp_T R_Type, cons
                              : build_vector_typed<STRSXP, uint64_t, rcpp_T::chr, NO_NULLS>(array);
 
         default:                                                      // # nocov
-            return Rcpp::LogicalVector(std::size(array), NA_LOGICAL); // # nocov
+            return Rcpp::LogicalVector(array.count_elements(), NA_LOGICAL); // # nocov
     }
 }
 
 
 template <int RTYPE>
-inline Rcpp::Vector<RTYPE> build_vector_mixed(simdjson::dom::array array) {
-    Rcpp::Vector<RTYPE> out(std::size(array));
+inline Rcpp::Vector<RTYPE> build_vector_mixed(simdjson::ondemand::array array) {
+    Rcpp::Vector<RTYPE> out(array.count_elements());
     R_xlen_t            i(0L);
     for (auto element : array) {
         out[i++] = get_scalar_dispatch<RTYPE>(element);
@@ -91,17 +91,17 @@ inline Rcpp::Vector<RTYPE> build_vector_mixed(simdjson::dom::array array) {
 }
 
 
-inline Rcpp::Vector<REALSXP> build_vector_integer64_mixed(simdjson::dom::array array) {
-    std::vector<int64_t> stl_vec_int64(std::size(array));
+inline Rcpp::Vector<REALSXP> build_vector_integer64_mixed(simdjson::ondemand::array array) {
+    std::vector<int64_t> stl_vec_int64(array.count_elements());
     std::size_t          i(0ULL);
 
     for (auto element : array) {
-        switch (element.type()) {
-            case simdjson::dom::element_type::INT64:
+        switch (utils::get_complete_json_type(element)) {
+            case utils::complete_json_type::int64:
                 stl_vec_int64[i++] = get_scalar<int64_t, rcpp_T::i64, HAS_NULLS>(element);
                 break;
 
-            case simdjson::dom::element_type::BOOL:
+            case utils::complete_json_type::boolean:
                 stl_vec_int64[i++] = get_scalar<bool, rcpp_T::i64, HAS_NULLS>(element);
                 break;
 
@@ -116,7 +116,7 @@ inline Rcpp::Vector<REALSXP> build_vector_integer64_mixed(simdjson::dom::array a
 
 
 template <utils::Int64_R_Type int64_opt>
-inline SEXP dispatch_mixed(simdjson::dom::array array, const rcpp_T common_R_type) {
+inline SEXP dispatch_mixed(simdjson::ondemand::array array, const rcpp_T common_R_type) {
     switch (common_R_type) {
         case rcpp_T::chr:
             return build_vector_mixed<STRSXP>(array);
@@ -150,7 +150,7 @@ inline SEXP dispatch_mixed(simdjson::dom::array array, const rcpp_T common_R_typ
             return build_vector_mixed<LGLSXP>(array);
 
         default:
-            return Rcpp::LogicalVector(std::size(array), NA_LOGICAL);
+            return Rcpp::LogicalVector(array.count_elements(), NA_LOGICAL);
             // # nocov end
     }
 }

--- a/inst/include/RcppSimdJson/deserialize/vector.hpp
+++ b/inst/include/RcppSimdJson/deserialize/vector.hpp
@@ -101,7 +101,7 @@ inline Rcpp::Vector<RTYPE> build_vector_mixed(simdjson::ondemand::array array) {
 
 
 inline Rcpp::Vector<REALSXP> build_vector_integer64_mixed(simdjson::ondemand::array array) {
-    std::vector<double> stl_vec_int64(array.count_elements());
+    std::vector<int64_t> stl_vec_int64(array.count_elements());
     std::size_t          i(0ULL);
 
     for (auto element : array) {
@@ -109,7 +109,7 @@ inline Rcpp::Vector<REALSXP> build_vector_integer64_mixed(simdjson::ondemand::ar
         if (element.get(val) == simdjson::SUCCESS) {
             switch (element.type()) {
                 case simdjson::ondemand::json_type::number:
-                    stl_vec_int64[i++] = get_scalar<double, rcpp_T::i64, HAS_NULLS>(val);
+                    stl_vec_int64[i++] = get_scalar<int64_t, rcpp_T::i64, HAS_NULLS>(val);
                     break;
 
                 case simdjson::ondemand::json_type::boolean:

--- a/inst/include/RcppSimdJson/utils.hpp
+++ b/inst/include/RcppSimdJson/utils.hpp
@@ -27,58 +27,6 @@ struct remove_cvref {
 namespace rcppsimdjson {
 namespace utils {
 
-/**
- * The complete type of a JSON value, including double, int and uint for numbers.
- **/
-enum class complete_json_type {
-    // Start at 1 to catch uninitialized / default values more easily
-    array=1, ///< A JSON array   ( [ 1, 2, 3 ... ] )
-    object,  ///< A JSON object  ( { "a": 1, "b" 2, ... } )
-    int64,  ///< A signed JSON integer  ( 1 or -2 or -1235623 ...)
-    uint64, ///< An unsigned JSON integer (1 or 123 or 135234 ...)
-    double, ///< A JSON double (-2.3 or 1.234e2 or 1.0 ...)
-    string,  ///< A JSON string  ( "a" or "hello world\n" ...)
-    boolean, ///< A JSON boolean (true or false)
-    null     ///< A JSON null    (null)
-}
-
-inline complete_json_type get_complete_type(simdjson::ondemand::value value) {
-    using simdjson::ondemand::json_type;
-
-    switch(value.type()) {
-        case json_type::array:
-            return complete_json_type::array;
-        case json_type::object:
-            return complete_json_type::object;
-        case json_type::number:
-            return get_number_type(value);
-        case json_type::string:
-            return complete_json_type::string;
-        case json_type::boolean:
-            return complete_json_type::bolean;
-        case json_type::null:
-            return complete_json_type::null;
-    }
-}
-
-/**
- * Get the type of a JSON number: double, int or uint.
- * Naive implementation. This does two parsings per number. This can be reduced to at most one parsing.
- **/
-inline complete_json_type get_number_type(simdjson::ondemand::value value)) {
-    auto is_uint = value.get_uint64();
-    auto is_int = value.get_int64();
-    if (is_uint.error() == SUCCESS) {
-        return complete_json_type::uint64;
-    }
-    else if (is_int.error() == SUCCESS) {
-        return complete_json_type::int64;
-    }
-    else {
-        return complete_json_type::double;
-    }
-}
-
 // options for returning big-ints
 enum class Int64_R_Type : int {
     Double    = 0,

--- a/inst/include/RcppSimdJson/utils.hpp
+++ b/inst/include/RcppSimdJson/utils.hpp
@@ -27,6 +27,58 @@ struct remove_cvref {
 namespace rcppsimdjson {
 namespace utils {
 
+/**
+ * The complete type of a JSON value, including double, int and uint for numbers.
+ **/
+enum class complete_json_type {
+    // Start at 1 to catch uninitialized / default values more easily
+    array=1, ///< A JSON array   ( [ 1, 2, 3 ... ] )
+    object,  ///< A JSON object  ( { "a": 1, "b" 2, ... } )
+    int64,  ///< A signed JSON integer  ( 1 or -2 or -1235623 ...)
+    uint64, ///< An unsigned JSON integer (1 or 123 or 135234 ...)
+    double, ///< A JSON double (-2.3 or 1.234e2 or 1.0 ...)
+    string,  ///< A JSON string  ( "a" or "hello world\n" ...)
+    boolean, ///< A JSON boolean (true or false)
+    null     ///< A JSON null    (null)
+}
+
+inline complete_json_type get_complete_type(simdjson::ondemand::value value) {
+    using simdjson::ondemand::json_type;
+
+    switch(value.type()) {
+        case json_type::array:
+            return complete_json_type::array;
+        case json_type::object:
+            return complete_json_type::object;
+        case json_type::number:
+            return get_number_type(value);
+        case json_type::string:
+            return complete_json_type::string;
+        case json_type::boolean:
+            return complete_json_type::bolean;
+        case json_type::null:
+            return complete_json_type::null;
+    }
+}
+
+/**
+ * Get the type of a JSON number: double, int or uint.
+ * Naive implementation. This does two parsings per number. This can be reduced to at most one parsing.
+ **/
+inline complete_json_type get_number_type(simdjson::ondemand::value value)) {
+    auto is_uint = value.get_uint64();
+    auto is_int = value.get_int64();
+    if (is_uint.error() == SUCCESS) {
+        return complete_json_type::uint64;
+    }
+    else if (is_int.error() == SUCCESS) {
+        return complete_json_type::int64;
+    }
+    else {
+        return complete_json_type::double;
+    }
+}
+
 // options for returning big-ints
 enum class Int64_R_Type : int {
     Double    = 0,

--- a/inst/include/simdjson.cpp
+++ b/inst/include/simdjson.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on 2021-03-18 11:30:40 -0400. Do not edit! */
+/* auto-generated on 2021-07-27 17:46:55 -0400. Do not edit! */
 /* begin file src/simdjson.cpp */
 #include "simdjson.h"
 
@@ -9,6 +9,8 @@ SIMDJSON_DISABLE_UNDESIRED_WARNINGS
 #include <cstring>
 #include <cstdint>
 #include <array>
+#include <cmath>
+
 namespace simdjson {
 namespace internal {
 /*!
@@ -866,9 +868,9 @@ inline char *format_buffer(char *buf, int len, int decimal_exponent,
 
     std::memset(buf + k, '0', static_cast<size_t>(n) - static_cast<size_t>(k));
     // Make it look like a floating-point number (#362, #378)
-    buf[n + 0] = '.';
-    buf[n + 1] = '0';
-    return buf + (static_cast<size_t>(n) + 2);
+    // buf[n + 0] = '.';
+    // buf[n + 1] = '0';
+    return buf + (static_cast<size_t>(n));
   }
 
   if (0 < n && n <= max_exp) {
@@ -921,7 +923,8 @@ format. Returns an iterator pointing past-the-end of the decimal representation.
 */
 char *to_chars(char *first, const char *last, double value) {
   static_cast<void>(last); // maybe unused - fix warning
-  if (value <= -0) {
+  bool negative = std::signbit(value);
+  if (negative) {
     value = -value;
     *first++ = '-';
   }
@@ -930,8 +933,10 @@ char *to_chars(char *first, const char *last, double value) {
   {
     *first++ = '0';
     // Make it look like a floating-point number (#362, #378)
-    *first++ = '.';
-    *first++ = '0';
+    if(negative) {
+      *first++ = '.';
+      *first++ = '0';
+    }
     return first;
   }
   // Compute v = buffer * 10^decimal_exponent.
@@ -1077,6 +1082,86 @@ decimal parse_decimal(const char *&p) noexcept {
     }
     int32_t exp_number = 0; // exponential part
     while (is_integer(*p)) {
+      uint8_t digit = uint8_t(*p - '0');
+      if (exp_number < 0x10000) {
+        exp_number = 10 * exp_number + digit;
+      }
+      ++p;
+    }
+    answer.decimal_point += (neg_exp ? -exp_number : exp_number);
+  }
+  return answer;
+}
+
+// This should always succeed since it follows a call to parse_number.
+// Will not read at or beyond the "end" pointer.
+decimal parse_decimal(const char *&p, const char * end) noexcept {
+  decimal answer;
+  answer.num_digits = 0;
+  answer.decimal_point = 0;
+  answer.truncated = false;
+  if(p == end) { return answer; } // should never happen
+  answer.negative = (*p == '-');
+  if ((*p == '-') || (*p == '+')) {
+    ++p;
+  }
+
+  while ((p != end) && (*p == '0')) {
+    ++p;
+  }
+  while ((p != end) && is_integer(*p)) {
+    if (answer.num_digits < max_digits) {
+      answer.digits[answer.num_digits] = uint8_t(*p - '0');
+    }
+    answer.num_digits++;
+    ++p;
+  }
+  if ((p != end) && (*p == '.')) {
+    ++p;
+    if(p == end) { return answer; } // should never happen
+    const char *first_after_period = p;
+    // if we have not yet encountered a zero, we have to skip it as well
+    if (answer.num_digits == 0) {
+      // skip zeros
+      while (*p == '0') {
+        ++p;
+      }
+    }
+    while ((p != end) && is_integer(*p)) {
+      if (answer.num_digits < max_digits) {
+        answer.digits[answer.num_digits] = uint8_t(*p - '0');
+      }
+      answer.num_digits++;
+      ++p;
+    }
+    answer.decimal_point = int32_t(first_after_period - p);
+  }
+  if(answer.num_digits > 0) {
+    const char *preverse = p - 1;
+    int32_t trailing_zeros = 0;
+    while ((*preverse == '0') || (*preverse == '.')) {
+      if(*preverse == '0') { trailing_zeros++; };
+      --preverse;
+    }
+    answer.decimal_point += int32_t(answer.num_digits);
+    answer.num_digits -= uint32_t(trailing_zeros);
+  }
+  if(answer.num_digits > max_digits ) {
+    answer.num_digits = max_digits;
+    answer.truncated = true;
+  }
+  if ((p != end) && (('e' == *p) || ('E' == *p))) {
+    ++p;
+    if(p == end) { return answer; } // should never happen
+    bool neg_exp = false;
+    if ('-' == *p) {
+      neg_exp = true;
+      ++p;
+    } else if ('+' == *p) {
+      ++p;
+    }
+    int32_t exp_number = 0; // exponential part
+    while ((p != end) && is_integer(*p)) {
       uint8_t digit = uint8_t(*p - '0');
       if (exp_number < 0x10000) {
         exp_number = 10 * exp_number + digit;
@@ -1427,12 +1512,35 @@ adjusted_mantissa parse_long_mantissa(const char *first) {
   return compute_float<binary>(d);
 }
 
+template <typename binary>
+adjusted_mantissa parse_long_mantissa(const char *first, const char *end) {
+  decimal d = parse_decimal(first, end);
+  return compute_float<binary>(d);
+}
+
 double from_chars(const char *first) noexcept {
   bool negative = first[0] == '-';
   if (negative) {
     first++;
   }
   adjusted_mantissa am = parse_long_mantissa<binary_format<double>>(first);
+  uint64_t word = am.mantissa;
+  word |= uint64_t(am.power2)
+          << binary_format<double>::mantissa_explicit_bits();
+  word = negative ? word | (uint64_t(1) << binary_format<double>::sign_index())
+                  : word;
+  double value;
+  std::memcpy(&value, &word, sizeof(double));
+  return value;
+}
+
+
+double from_chars(const char *first, const char *end) noexcept {
+  bool negative = first[0] == '-';
+  if (negative) {
+    first++;
+  }
+  adjusted_mantissa am = parse_long_mantissa<binary_format<double>>(first, end);
   uint64_t word = am.mantissa;
   word |= uint64_t(am.power2)
           << binary_format<double>::mantissa_explicit_bits();
@@ -1478,7 +1586,8 @@ namespace internal {
     { UNEXPECTED_ERROR, "Unexpected error, consider reporting this problem as you may have found a bug in simdjson" },
     { PARSER_IN_USE, "Cannot parse a new document while a document is still in use." },
     { OUT_OF_ORDER_ITERATION, "Objects and arrays can only be iterated when they are first encountered." },
-    { INSUFFICIENT_PADDING, "simdjson requires the input JSON string to have at least SIMDJSON_PADDING extra bytes allocated, beyond the string's length." }
+    { INSUFFICIENT_PADDING, "simdjson requires the input JSON string to have at least SIMDJSON_PADDING extra bytes allocated, beyond the string's length." },
+    { INCOMPLETE_ARRAY_OR_OBJECT, "JSON document ended early in the middle of an object or array." }
   }; // error_messages[]
 
 } // namespace internal
@@ -2674,8 +2783,10 @@ simdjson_warn_unused error_code implementation::create_dom_parser_implementation
 ) const noexcept {
   dst.reset( new (std::nothrow) dom_parser_implementation() );
   if (!dst) { return MEMALLOC; }
-  dst->set_capacity(capacity);
-  dst->set_max_depth(max_depth);
+  if (auto err = dst->set_capacity(capacity))
+    return err;
+  if (auto err = dst->set_max_depth(max_depth))
+    return err;
   return SUCCESS;
 }
 
@@ -2962,7 +3073,6 @@ using namespace simd;
         }
         this->prev_incomplete = is_incomplete(input.chunks[simd8x64<uint8_t>::NUM_CHUNKS-1]);
         this->prev_input_block = input.chunks[simd8x64<uint8_t>::NUM_CHUNKS-1];
-
       }
     }
     // do not forget to call check_eof!
@@ -3505,8 +3615,8 @@ namespace {
   *
   * Simply put, we iterate over the structural characters, starting from
   * the end. We consider that we found the end of a JSON document when the
-  * first element of the pair is NOT one of these characters: '{' '[' ';' ','
-  * and when the second element is NOT one of these characters: '}' '}' ';' ','.
+  * first element of the pair is NOT one of these characters: '{' '[' ':' ','
+  * and when the second element is NOT one of these characters: '}' ']' ':' ','.
   *
   * This simple comparison works most of the time, but it does not cover cases
   * where the batch's structural indexes contain a perfect amount of documents.
@@ -3520,7 +3630,8 @@ namespace {
   * batch.
   */
 simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementation &parser) {
-  // TODO don't count separately, just figure out depth
+  // Variant: do not count separately, just figure out depth
+  if(parser.n_structural_indexes == 0) { return 0; }
   auto arr_cnt = 0;
   auto obj_cnt = 0;
   for (auto i = parser.n_structural_indexes - 1; i > 0; i--) {
@@ -3557,6 +3668,25 @@ simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementati
     // Last document is incomplete; mark the document at i + 1 as the next one
     return i;
   }
+  // If we made it to the end, we want to finish counting to see if we have a full document.
+  switch (parser.buf[parser.structural_indexes[0]]) {
+    case '}':
+      obj_cnt--;
+      break;
+    case ']':
+      arr_cnt--;
+      break;
+    case '{':
+      obj_cnt++;
+      break;
+    case '[':
+      arr_cnt++;
+      break;
+  }
+  if (!arr_cnt && !obj_cnt) {
+    // We have a complete document.
+    return parser.n_structural_indexes;
+  }
   return 0;
 }
 
@@ -3587,8 +3717,62 @@ public:
     // it helps tremendously.
     if (bits == 0)
         return;
-    int cnt = static_cast<int>(count_ones(bits));
+#if defined(SIMDJSON_PREFER_REVERSE_BITS)
+    /**
+     * ARM lacks a fast trailing zero instruction, but it has a fast
+     * bit reversal instruction and a fast leading zero instruction.
+     * Thus it may be profitable to reverse the bits (once) and then
+     * to rely on a sequence of instructions that call the leading
+     * zero instruction.
+     *
+     * Performance notes:
+     * The chosen routine is not optimal in terms of data dependency
+     * since zero_leading_bit might require two instructions. However,
+     * it tends to minimize the total number of instructions which is
+     * beneficial.
+     */
 
+    uint64_t rev_bits = reverse_bits(bits);
+    int cnt = static_cast<int>(count_ones(bits));
+    int i = 0;
+    // Do the first 8 all together
+    for (; i<8; i++) {
+      int lz = leading_zeroes(rev_bits);
+      this->tail[i] = static_cast<uint32_t>(idx) + lz;
+      rev_bits = zero_leading_bit(rev_bits, lz);
+    }
+    // Do the next 8 all together (we hope in most cases it won't happen at all
+    // and the branch is easily predicted).
+    if (simdjson_unlikely(cnt > 8)) {
+      i = 8;
+      for (; i<16; i++) {
+        int lz = leading_zeroes(rev_bits);
+        this->tail[i] = static_cast<uint32_t>(idx) + lz;
+        rev_bits = zero_leading_bit(rev_bits, lz);
+      }
+
+
+      // Most files don't have 16+ structurals per block, so we take several basically guaranteed
+      // branch mispredictions here. 16+ structurals per block means either punctuation ({} [] , :)
+      // or the start of a value ("abc" true 123) every four characters.
+      if (simdjson_unlikely(cnt > 16)) {
+        i = 16;
+        while (rev_bits != 0) {
+          int lz = leading_zeroes(rev_bits);
+          this->tail[i++] = static_cast<uint32_t>(idx) + lz;
+          rev_bits = zero_leading_bit(rev_bits, lz);
+        }
+      }
+    }
+    this->tail += cnt;
+#else // SIMDJSON_PREFER_REVERSE_BITS
+    /**
+     * Under recent x64 systems, we often have both a fast trailing zero
+     * instruction and a fast 'clear-lower-bit' instruction so the following
+     * algorithm can be competitive.
+     */
+
+    int cnt = static_cast<int>(count_ones(bits));
     // Do the first 8 all together
     for (int i=0; i<8; i++) {
       this->tail[i] = idx + trailing_zeroes(bits);
@@ -3617,6 +3801,7 @@ public:
     }
 
     this->tail += cnt;
+#endif
   }
 };
 
@@ -3630,14 +3815,14 @@ public:
    *   you are processing substrings, you may want to call on a function like trimmed_length_safe_utf8.
    */
   template<size_t STEP_SIZE>
-  static error_code index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, bool partial) noexcept;
+  static error_code index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, stage1_mode partial) noexcept;
 
 private:
   simdjson_really_inline json_structural_indexer(uint32_t *structural_indexes);
   template<size_t STEP_SIZE>
   simdjson_really_inline void step(const uint8_t *block, buf_block_reader<STEP_SIZE> &reader) noexcept;
   simdjson_really_inline void next(const simd::simd8x64<uint8_t>& in, const json_block& block, size_t idx);
-  simdjson_really_inline error_code finish(dom_parser_implementation &parser, size_t idx, size_t len, bool partial);
+  simdjson_really_inline error_code finish(dom_parser_implementation &parser, size_t idx, size_t len, stage1_mode partial);
 
   json_scanner scanner{};
   utf8_checker checker{};
@@ -3687,10 +3872,17 @@ simdjson_really_inline size_t trim_partial_utf8(const uint8_t *buf, size_t len) 
 // workout.
 //
 template<size_t STEP_SIZE>
-error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, bool partial) noexcept {
+error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, stage1_mode partial) noexcept {
   if (simdjson_unlikely(len > parser.capacity())) { return CAPACITY; }
-  if (partial) { len = trim_partial_utf8(buf, len); }
-
+  // We guard the rest of the code so that we can assume that len > 0 throughout.
+  if (len == 0) { return EMPTY; }
+  if (is_streaming(partial)) {
+    len = trim_partial_utf8(buf, len);
+    // If you end up with an empty window after trimming
+    // the partial UTF-8 bytes, then chances are good that you
+    // have an UTF-8 formatting error.
+    if(len == 0) { return UTF8_ERROR; }
+  }
   buf_block_reader<STEP_SIZE> reader(buf, len);
   json_structural_indexer indexer(parser.structural_indexes.get());
 
@@ -3698,12 +3890,11 @@ error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_pa
   while (reader.has_full_block()) {
     indexer.step<STEP_SIZE>(reader.full_block(), reader);
   }
-
-  // Take care of the last block (will always be there unless file is empty)
+  // Take care of the last block (will always be there unless file is empty which is
+  // not supposed to happen.)
   uint8_t block[STEP_SIZE];
-  if (simdjson_unlikely(reader.get_remainder(block) == 0)) { return EMPTY; }
+  if (simdjson_unlikely(reader.get_remainder(block) == 0)) { return UNEXPECTED_ERROR; }
   indexer.step<STEP_SIZE>(block, reader);
-
   return indexer.finish(parser, reader.block_index(), len, partial);
 }
 
@@ -3734,14 +3925,13 @@ simdjson_really_inline void json_structural_indexer::next(const simd::simd8x64<u
   unescaped_chars_error |= block.non_quote_inside_string(unescaped);
 }
 
-simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_implementation &parser, size_t idx, size_t len, bool partial) {
+simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_implementation &parser, size_t idx, size_t len, stage1_mode partial) {
   // Write out the final iteration's structurals
   indexer.write(uint32_t(idx-64), prev_structurals);
-
   error_code error = scanner.finish();
   // We deliberately break down the next expression so that it is
   // human readable.
-  const bool should_we_exit =  partial ?
+  const bool should_we_exit = is_streaming(partial) ?
     ((error != SUCCESS) && (error != UNCLOSED_STRING)) // when partial we tolerate UNCLOSED_STRING
     : (error != SUCCESS); // if partial is false, we must have SUCCESS
   const bool have_unclosed_string = (error == UNCLOSED_STRING);
@@ -3750,9 +3940,10 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
   if (unescaped_chars_error) {
     return UNESCAPED_CHARS;
   }
-
   parser.n_structural_indexes = uint32_t(indexer.tail - parser.structural_indexes.get());
   /***
+   * The On Demand API requires special padding.
+   *
    * This is related to https://github.com/simdjson/simdjson/issues/906
    * Basically, we want to make sure that if the parsing continues beyond the last (valid)
    * structural character, it quickly stops.
@@ -3765,8 +3956,11 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
    * if the repeated character is [. But if so, the document must start with [. But if the document
    * starts with [, it should end with ]. If we enforce that rule, then we would get
    * ][[ which is invalid.
+   *
+   * This is illustrated with the test array_iterate_unclosed_error() on the following input:
+   * R"({ "a": [,,)"
    **/
-  parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
+  parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len); // used later in partial == stage1_mode::streaming_final
   parser.structural_indexes[parser.n_structural_indexes + 1] = uint32_t(len);
   parser.structural_indexes[parser.n_structural_indexes + 2] = 0;
   parser.next_structural_index = 0;
@@ -3777,7 +3971,7 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
   if (simdjson_unlikely(parser.structural_indexes[parser.n_structural_indexes - 1] > len)) {
     return UNEXPECTED_ERROR;
   }
-  if (partial) {
+  if (partial == stage1_mode::streaming_partial) {
     // If we have an unclosed string, then the last structural
     // will be the quote and we want to make sure to omit it.
     if(have_unclosed_string) {
@@ -3785,11 +3979,48 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
       // a valid JSON file cannot have zero structural indexes - we should have found something
       if (simdjson_unlikely(parser.n_structural_indexes == 0u)) { return CAPACITY; }
     }
+    // We truncate the input to the end of the last complete document (or zero).
     auto new_structural_indexes = find_next_document_index(parser);
     if (new_structural_indexes == 0 && parser.n_structural_indexes > 0) {
-      return CAPACITY; // If the buffer is partial but the document is incomplete, it's too big to parse.
+      if(parser.structural_indexes[0] == 0) {
+        // If the buffer is partial and we started at index 0 but the document is
+        // incomplete, it's too big to parse.
+        return CAPACITY;
+      } else {
+        // It is possible that the document could be parsed, we just had a lot
+        // of white space.
+        parser.n_structural_indexes = 0;
+        return EMPTY;
+      }
     }
+
     parser.n_structural_indexes = new_structural_indexes;
+  } else if (partial == stage1_mode::streaming_final) {
+    if(have_unclosed_string) { parser.n_structural_indexes--; }
+    // We truncate the input to the end of the last complete document (or zero).
+    // Because partial == stage1_mode::streaming_final, it means that we may
+    // silently ignore trailing garbage. Though it sounds bad, we do it
+    // deliberately because many people who have streams of JSON documents
+    // will truncate them for processing. E.g., imagine that you are uncompressing
+    // the data from a size file or receiving it in chunks from the network. You
+    // may not know where exactly the last document will be. Meanwhile the
+    // document_stream instances allow people to know the JSON documents they are
+    // parsing (see the iterator.source() method).
+    parser.n_structural_indexes = find_next_document_index(parser);
+    // We store the initial n_structural_indexes so that the client can see
+    // whether we used truncation. If initial_n_structural_indexes == parser.n_structural_indexes,
+    // then this will query parser.structural_indexes[parser.n_structural_indexes] which is len,
+    // otherwise, it will copy some prior index.
+    parser.structural_indexes[parser.n_structural_indexes + 1] = parser.structural_indexes[parser.n_structural_indexes];
+    // This next line is critical, do not change it unless you understand what you are
+    // doing.
+    parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
+    if (simdjson_unlikely(parser.n_structural_indexes == 0u)) {
+        // We tolerate an unclosed string at the very end of the stream. Indeed, users
+        // often load their data in bulk without being careful and they want us to ignore
+        // the trailing garbage.
+        return EMPTY;
+    }
   }
   checker.check_eof();
   return checker.errors();
@@ -4059,12 +4290,12 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::walk_docum
   {
     auto value = advance();
 
-    // Make sure the outer hash or array is closed before continuing; otherwise, there are ways we
+    // Make sure the outer object or array is closed before continuing; otherwise, there are ways we
     // could get into memory corruption. See https://github.com/simdjson/simdjson/issues/906
     if (!STREAMING) {
       switch (*value) {
-        case '{': if (last_structural() != '}') { return TAPE_ERROR; }; break;
-        case '[': if (last_structural() != ']') { return TAPE_ERROR; }; break;
+        case '{': if (last_structural() != '}') { log_value("starting brace unmatched"); return TAPE_ERROR; }; break;
+        case '[': if (last_structural() != ']') { log_value("starting bracket unmatched"); return TAPE_ERROR; }; break;
       }
     }
 
@@ -4662,7 +4893,7 @@ simdjson_warn_unused error_code implementation::minify(const uint8_t *buf, size_
   return arm64::stage1::json_minifier::minify<64>(buf, len, dst, dst_len);
 }
 
-simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool streaming) noexcept {
+simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, stage1_mode streaming) noexcept {
   this->buf = _buf;
   this->len = _len;
   return arm64::stage1::json_structural_indexer::index<64>(buf, len, *this, streaming);
@@ -4681,7 +4912,7 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
 }
 
 simdjson_warn_unused error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {
-  auto error = stage1(_buf, _len, false);
+  auto error = stage1(_buf, _len, stage1_mode::regular);
   if (error) { return error; }
   return stage2(_doc);
 }
@@ -4710,8 +4941,10 @@ simdjson_warn_unused error_code implementation::create_dom_parser_implementation
 ) const noexcept {
   dst.reset( new (std::nothrow) dom_parser_implementation() );
   if (!dst) { return MEMALLOC; }
-  dst->set_capacity(capacity);
-  dst->set_max_depth(max_depth);
+  if (auto err = dst->set_capacity(capacity))
+    return err;
+  if (auto err = dst->set_max_depth(max_depth))
+    return err;
   return SUCCESS;
 }
 
@@ -4746,8 +4979,8 @@ namespace {
   *
   * Simply put, we iterate over the structural characters, starting from
   * the end. We consider that we found the end of a JSON document when the
-  * first element of the pair is NOT one of these characters: '{' '[' ';' ','
-  * and when the second element is NOT one of these characters: '}' '}' ';' ','.
+  * first element of the pair is NOT one of these characters: '{' '[' ':' ','
+  * and when the second element is NOT one of these characters: '}' ']' ':' ','.
   *
   * This simple comparison works most of the time, but it does not cover cases
   * where the batch's structural indexes contain a perfect amount of documents.
@@ -4761,7 +4994,8 @@ namespace {
   * batch.
   */
 simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementation &parser) {
-  // TODO don't count separately, just figure out depth
+  // Variant: do not count separately, just figure out depth
+  if(parser.n_structural_indexes == 0) { return 0; }
   auto arr_cnt = 0;
   auto obj_cnt = 0;
   for (auto i = parser.n_structural_indexes - 1; i > 0; i--) {
@@ -4798,6 +5032,25 @@ simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementati
     // Last document is incomplete; mark the document at i + 1 as the next one
     return i;
   }
+  // If we made it to the end, we want to finish counting to see if we have a full document.
+  switch (parser.buf[parser.structural_indexes[0]]) {
+    case '}':
+      obj_cnt--;
+      break;
+    case ']':
+      arr_cnt--;
+      break;
+    case '{':
+      obj_cnt++;
+      break;
+    case '[':
+      arr_cnt++;
+      break;
+  }
+  if (!arr_cnt && !obj_cnt) {
+    // We have a complete document.
+    return parser.n_structural_indexes;
+  }
   return 0;
 }
 
@@ -4814,7 +5067,7 @@ namespace stage1 {
 class structural_scanner {
 public:
 
-simdjson_really_inline structural_scanner(dom_parser_implementation &_parser, bool _partial)
+simdjson_really_inline structural_scanner(dom_parser_implementation &_parser, stage1_mode _partial)
   : buf{_parser.buf},
     next_structural_index{_parser.structural_indexes.get()},
     parser{_parser},
@@ -4844,7 +5097,7 @@ simdjson_really_inline void validate_utf8_character() {
   if ((buf[idx] & 0b00100000) == 0) {
     // missing continuation
     if (simdjson_unlikely(idx+1 > len || !is_continuation(buf[idx+1]))) {
-      if (idx+1 > len && partial) { idx = len; return; }
+      if (idx+1 > len && is_streaming(partial)) { idx = len; return; }
       error = UTF8_ERROR;
       idx++;
       return;
@@ -4859,7 +5112,7 @@ simdjson_really_inline void validate_utf8_character() {
   if ((buf[idx] & 0b00010000) == 0) {
     // missing continuation
     if (simdjson_unlikely(idx+2 > len || !is_continuation(buf[idx+1]) || !is_continuation(buf[idx+2]))) {
-      if (idx+2 > len && partial) { idx = len; return; }
+      if (idx+2 > len && is_streaming(partial)) { idx = len; return; }
       error = UTF8_ERROR;
       idx++;
       return;
@@ -4875,7 +5128,7 @@ simdjson_really_inline void validate_utf8_character() {
   // 4-byte
   // missing continuation
   if (simdjson_unlikely(idx+3 > len || !is_continuation(buf[idx+1]) || !is_continuation(buf[idx+2]) || !is_continuation(buf[idx+3]))) {
-    if (idx+2 > len && partial) { idx = len; return; }
+    if (idx+2 > len && is_streaming(partial)) { idx = len; return; }
     error = UTF8_ERROR;
     idx++;
     return;
@@ -4948,24 +5201,56 @@ simdjson_really_inline error_code scan() {
         break;
     }
   }
-  *next_structural_index = len;
   // We pad beyond.
   // https://github.com/simdjson/simdjson/issues/906
+  // See json_structural_indexer.h for an explanation.
+  *next_structural_index = len; // assumed later in partial == stage1_mode::streaming_final
   next_structural_index[1] = len;
   next_structural_index[2] = 0;
   parser.n_structural_indexes = uint32_t(next_structural_index - parser.structural_indexes.get());
   if (simdjson_unlikely(parser.n_structural_indexes == 0)) { return EMPTY; }
   parser.next_structural_index = 0;
-  if (partial) {
+  if (partial == stage1_mode::streaming_partial) {
     if(unclosed_string) {
       parser.n_structural_indexes--;
       if (simdjson_unlikely(parser.n_structural_indexes == 0)) { return CAPACITY; }
     }
+    // We truncate the input to the end of the last complete document (or zero).
     auto new_structural_indexes = find_next_document_index(parser);
     if (new_structural_indexes == 0 && parser.n_structural_indexes > 0) {
-      return CAPACITY; // If the buffer is partial but the document is incomplete, it's too big to parse.
+      if(parser.structural_indexes[0] == 0) {
+        // If the buffer is partial and we started at index 0 but the document is
+        // incomplete, it's too big to parse.
+        return CAPACITY;
+      } else {
+        // It is possible that the document could be parsed, we just had a lot
+        // of white space.
+        parser.n_structural_indexes = 0;
+        return EMPTY;
+      }
     }
     parser.n_structural_indexes = new_structural_indexes;
+  } else if(partial == stage1_mode::streaming_final) {
+    if(unclosed_string) { parser.n_structural_indexes--; }
+    // We truncate the input to the end of the last complete document (or zero).
+    // Because partial == stage1_mode::streaming_final, it means that we may
+    // silently ignore trailing garbage. Though it sounds bad, we do it
+    // deliberately because many people who have streams of JSON documents
+    // will truncate them for processing. E.g., imagine that you are uncompressing
+    // the data from a size file or receiving it in chunks from the network. You
+    // may not know where exactly the last document will be. Meanwhile the
+    // document_stream instances allow people to know the JSON documents they are
+    // parsing (see the iterator.source() method).
+    parser.n_structural_indexes = find_next_document_index(parser);
+    // We store the initial n_structural_indexes so that the client can see
+    // whether we used truncation. If initial_n_structural_indexes == parser.n_structural_indexes,
+    // then this will query parser.structural_indexes[parser.n_structural_indexes] which is len,
+    // otherwise, it will copy some prior index.
+    parser.structural_indexes[parser.n_structural_indexes + 1] = parser.structural_indexes[parser.n_structural_indexes];
+    // This next line is critical, do not change it unless you understand what you are
+    // doing.
+    parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
+    if (parser.n_structural_indexes == 0) { return EMPTY; }
   } else if(unclosed_string) { error = UNCLOSED_STRING; }
   return error;
 }
@@ -4977,13 +5262,13 @@ private:
   uint32_t len;
   uint32_t idx{0};
   error_code error{SUCCESS};
-  bool partial;
+  stage1_mode partial;
 }; // structural_scanner
 
 } // namespace stage1
 } // unnamed namespace
 
-simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool partial) noexcept {
+simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, stage1_mode partial) noexcept {
   this->buf = _buf;
   this->len = _len;
   stage1::structural_scanner scanner(*this, partial);
@@ -5333,12 +5618,12 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::walk_docum
   {
     auto value = advance();
 
-    // Make sure the outer hash or array is closed before continuing; otherwise, there are ways we
+    // Make sure the outer object or array is closed before continuing; otherwise, there are ways we
     // could get into memory corruption. See https://github.com/simdjson/simdjson/issues/906
     if (!STREAMING) {
       switch (*value) {
-        case '{': if (last_structural() != '}') { return TAPE_ERROR; }; break;
-        case '[': if (last_structural() != ']') { return TAPE_ERROR; }; break;
+        case '{': if (last_structural() != '}') { log_value("starting brace unmatched"); return TAPE_ERROR; }; break;
+        case '[': if (last_structural() != ']') { log_value("starting bracket unmatched"); return TAPE_ERROR; }; break;
       }
     }
 
@@ -5926,7 +6211,7 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
 }
 
 simdjson_warn_unused error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {
-  auto error = stage1(_buf, _len, false);
+  auto error = stage1(_buf, _len, stage1_mode::regular);
   if (error) { return error; }
   return stage2(_doc);
 }
@@ -5956,8 +6241,10 @@ simdjson_warn_unused error_code implementation::create_dom_parser_implementation
 ) const noexcept {
   dst.reset( new (std::nothrow) dom_parser_implementation() );
   if (!dst) { return MEMALLOC; }
-  dst->set_capacity(capacity);
-  dst->set_max_depth(max_depth);
+  if (auto err = dst->set_capacity(capacity))
+    return err;
+  if (auto err = dst->set_max_depth(max_depth))
+    return err;
   return SUCCESS;
 }
 
@@ -6251,7 +6538,6 @@ using namespace simd;
         }
         this->prev_incomplete = is_incomplete(input.chunks[simd8x64<uint8_t>::NUM_CHUNKS-1]);
         this->prev_input_block = input.chunks[simd8x64<uint8_t>::NUM_CHUNKS-1];
-
       }
     }
     // do not forget to call check_eof!
@@ -6794,8 +7080,8 @@ namespace {
   *
   * Simply put, we iterate over the structural characters, starting from
   * the end. We consider that we found the end of a JSON document when the
-  * first element of the pair is NOT one of these characters: '{' '[' ';' ','
-  * and when the second element is NOT one of these characters: '}' '}' ';' ','.
+  * first element of the pair is NOT one of these characters: '{' '[' ':' ','
+  * and when the second element is NOT one of these characters: '}' ']' ':' ','.
   *
   * This simple comparison works most of the time, but it does not cover cases
   * where the batch's structural indexes contain a perfect amount of documents.
@@ -6809,7 +7095,8 @@ namespace {
   * batch.
   */
 simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementation &parser) {
-  // TODO don't count separately, just figure out depth
+  // Variant: do not count separately, just figure out depth
+  if(parser.n_structural_indexes == 0) { return 0; }
   auto arr_cnt = 0;
   auto obj_cnt = 0;
   for (auto i = parser.n_structural_indexes - 1; i > 0; i--) {
@@ -6846,6 +7133,25 @@ simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementati
     // Last document is incomplete; mark the document at i + 1 as the next one
     return i;
   }
+  // If we made it to the end, we want to finish counting to see if we have a full document.
+  switch (parser.buf[parser.structural_indexes[0]]) {
+    case '}':
+      obj_cnt--;
+      break;
+    case ']':
+      arr_cnt--;
+      break;
+    case '{':
+      obj_cnt++;
+      break;
+    case '[':
+      arr_cnt++;
+      break;
+  }
+  if (!arr_cnt && !obj_cnt) {
+    // We have a complete document.
+    return parser.n_structural_indexes;
+  }
   return 0;
 }
 
@@ -6876,8 +7182,62 @@ public:
     // it helps tremendously.
     if (bits == 0)
         return;
-    int cnt = static_cast<int>(count_ones(bits));
+#if defined(SIMDJSON_PREFER_REVERSE_BITS)
+    /**
+     * ARM lacks a fast trailing zero instruction, but it has a fast
+     * bit reversal instruction and a fast leading zero instruction.
+     * Thus it may be profitable to reverse the bits (once) and then
+     * to rely on a sequence of instructions that call the leading
+     * zero instruction.
+     *
+     * Performance notes:
+     * The chosen routine is not optimal in terms of data dependency
+     * since zero_leading_bit might require two instructions. However,
+     * it tends to minimize the total number of instructions which is
+     * beneficial.
+     */
 
+    uint64_t rev_bits = reverse_bits(bits);
+    int cnt = static_cast<int>(count_ones(bits));
+    int i = 0;
+    // Do the first 8 all together
+    for (; i<8; i++) {
+      int lz = leading_zeroes(rev_bits);
+      this->tail[i] = static_cast<uint32_t>(idx) + lz;
+      rev_bits = zero_leading_bit(rev_bits, lz);
+    }
+    // Do the next 8 all together (we hope in most cases it won't happen at all
+    // and the branch is easily predicted).
+    if (simdjson_unlikely(cnt > 8)) {
+      i = 8;
+      for (; i<16; i++) {
+        int lz = leading_zeroes(rev_bits);
+        this->tail[i] = static_cast<uint32_t>(idx) + lz;
+        rev_bits = zero_leading_bit(rev_bits, lz);
+      }
+
+
+      // Most files don't have 16+ structurals per block, so we take several basically guaranteed
+      // branch mispredictions here. 16+ structurals per block means either punctuation ({} [] , :)
+      // or the start of a value ("abc" true 123) every four characters.
+      if (simdjson_unlikely(cnt > 16)) {
+        i = 16;
+        while (rev_bits != 0) {
+          int lz = leading_zeroes(rev_bits);
+          this->tail[i++] = static_cast<uint32_t>(idx) + lz;
+          rev_bits = zero_leading_bit(rev_bits, lz);
+        }
+      }
+    }
+    this->tail += cnt;
+#else // SIMDJSON_PREFER_REVERSE_BITS
+    /**
+     * Under recent x64 systems, we often have both a fast trailing zero
+     * instruction and a fast 'clear-lower-bit' instruction so the following
+     * algorithm can be competitive.
+     */
+
+    int cnt = static_cast<int>(count_ones(bits));
     // Do the first 8 all together
     for (int i=0; i<8; i++) {
       this->tail[i] = idx + trailing_zeroes(bits);
@@ -6906,6 +7266,7 @@ public:
     }
 
     this->tail += cnt;
+#endif
   }
 };
 
@@ -6919,14 +7280,14 @@ public:
    *   you are processing substrings, you may want to call on a function like trimmed_length_safe_utf8.
    */
   template<size_t STEP_SIZE>
-  static error_code index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, bool partial) noexcept;
+  static error_code index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, stage1_mode partial) noexcept;
 
 private:
   simdjson_really_inline json_structural_indexer(uint32_t *structural_indexes);
   template<size_t STEP_SIZE>
   simdjson_really_inline void step(const uint8_t *block, buf_block_reader<STEP_SIZE> &reader) noexcept;
   simdjson_really_inline void next(const simd::simd8x64<uint8_t>& in, const json_block& block, size_t idx);
-  simdjson_really_inline error_code finish(dom_parser_implementation &parser, size_t idx, size_t len, bool partial);
+  simdjson_really_inline error_code finish(dom_parser_implementation &parser, size_t idx, size_t len, stage1_mode partial);
 
   json_scanner scanner{};
   utf8_checker checker{};
@@ -6976,10 +7337,17 @@ simdjson_really_inline size_t trim_partial_utf8(const uint8_t *buf, size_t len) 
 // workout.
 //
 template<size_t STEP_SIZE>
-error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, bool partial) noexcept {
+error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, stage1_mode partial) noexcept {
   if (simdjson_unlikely(len > parser.capacity())) { return CAPACITY; }
-  if (partial) { len = trim_partial_utf8(buf, len); }
-
+  // We guard the rest of the code so that we can assume that len > 0 throughout.
+  if (len == 0) { return EMPTY; }
+  if (is_streaming(partial)) {
+    len = trim_partial_utf8(buf, len);
+    // If you end up with an empty window after trimming
+    // the partial UTF-8 bytes, then chances are good that you
+    // have an UTF-8 formatting error.
+    if(len == 0) { return UTF8_ERROR; }
+  }
   buf_block_reader<STEP_SIZE> reader(buf, len);
   json_structural_indexer indexer(parser.structural_indexes.get());
 
@@ -6987,12 +7355,11 @@ error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_pa
   while (reader.has_full_block()) {
     indexer.step<STEP_SIZE>(reader.full_block(), reader);
   }
-
-  // Take care of the last block (will always be there unless file is empty)
+  // Take care of the last block (will always be there unless file is empty which is
+  // not supposed to happen.)
   uint8_t block[STEP_SIZE];
-  if (simdjson_unlikely(reader.get_remainder(block) == 0)) { return EMPTY; }
+  if (simdjson_unlikely(reader.get_remainder(block) == 0)) { return UNEXPECTED_ERROR; }
   indexer.step<STEP_SIZE>(block, reader);
-
   return indexer.finish(parser, reader.block_index(), len, partial);
 }
 
@@ -7023,14 +7390,13 @@ simdjson_really_inline void json_structural_indexer::next(const simd::simd8x64<u
   unescaped_chars_error |= block.non_quote_inside_string(unescaped);
 }
 
-simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_implementation &parser, size_t idx, size_t len, bool partial) {
+simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_implementation &parser, size_t idx, size_t len, stage1_mode partial) {
   // Write out the final iteration's structurals
   indexer.write(uint32_t(idx-64), prev_structurals);
-
   error_code error = scanner.finish();
   // We deliberately break down the next expression so that it is
   // human readable.
-  const bool should_we_exit =  partial ?
+  const bool should_we_exit = is_streaming(partial) ?
     ((error != SUCCESS) && (error != UNCLOSED_STRING)) // when partial we tolerate UNCLOSED_STRING
     : (error != SUCCESS); // if partial is false, we must have SUCCESS
   const bool have_unclosed_string = (error == UNCLOSED_STRING);
@@ -7039,9 +7405,10 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
   if (unescaped_chars_error) {
     return UNESCAPED_CHARS;
   }
-
   parser.n_structural_indexes = uint32_t(indexer.tail - parser.structural_indexes.get());
   /***
+   * The On Demand API requires special padding.
+   *
    * This is related to https://github.com/simdjson/simdjson/issues/906
    * Basically, we want to make sure that if the parsing continues beyond the last (valid)
    * structural character, it quickly stops.
@@ -7054,8 +7421,11 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
    * if the repeated character is [. But if so, the document must start with [. But if the document
    * starts with [, it should end with ]. If we enforce that rule, then we would get
    * ][[ which is invalid.
+   *
+   * This is illustrated with the test array_iterate_unclosed_error() on the following input:
+   * R"({ "a": [,,)"
    **/
-  parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
+  parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len); // used later in partial == stage1_mode::streaming_final
   parser.structural_indexes[parser.n_structural_indexes + 1] = uint32_t(len);
   parser.structural_indexes[parser.n_structural_indexes + 2] = 0;
   parser.next_structural_index = 0;
@@ -7066,7 +7436,7 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
   if (simdjson_unlikely(parser.structural_indexes[parser.n_structural_indexes - 1] > len)) {
     return UNEXPECTED_ERROR;
   }
-  if (partial) {
+  if (partial == stage1_mode::streaming_partial) {
     // If we have an unclosed string, then the last structural
     // will be the quote and we want to make sure to omit it.
     if(have_unclosed_string) {
@@ -7074,11 +7444,48 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
       // a valid JSON file cannot have zero structural indexes - we should have found something
       if (simdjson_unlikely(parser.n_structural_indexes == 0u)) { return CAPACITY; }
     }
+    // We truncate the input to the end of the last complete document (or zero).
     auto new_structural_indexes = find_next_document_index(parser);
     if (new_structural_indexes == 0 && parser.n_structural_indexes > 0) {
-      return CAPACITY; // If the buffer is partial but the document is incomplete, it's too big to parse.
+      if(parser.structural_indexes[0] == 0) {
+        // If the buffer is partial and we started at index 0 but the document is
+        // incomplete, it's too big to parse.
+        return CAPACITY;
+      } else {
+        // It is possible that the document could be parsed, we just had a lot
+        // of white space.
+        parser.n_structural_indexes = 0;
+        return EMPTY;
+      }
     }
+
     parser.n_structural_indexes = new_structural_indexes;
+  } else if (partial == stage1_mode::streaming_final) {
+    if(have_unclosed_string) { parser.n_structural_indexes--; }
+    // We truncate the input to the end of the last complete document (or zero).
+    // Because partial == stage1_mode::streaming_final, it means that we may
+    // silently ignore trailing garbage. Though it sounds bad, we do it
+    // deliberately because many people who have streams of JSON documents
+    // will truncate them for processing. E.g., imagine that you are uncompressing
+    // the data from a size file or receiving it in chunks from the network. You
+    // may not know where exactly the last document will be. Meanwhile the
+    // document_stream instances allow people to know the JSON documents they are
+    // parsing (see the iterator.source() method).
+    parser.n_structural_indexes = find_next_document_index(parser);
+    // We store the initial n_structural_indexes so that the client can see
+    // whether we used truncation. If initial_n_structural_indexes == parser.n_structural_indexes,
+    // then this will query parser.structural_indexes[parser.n_structural_indexes] which is len,
+    // otherwise, it will copy some prior index.
+    parser.structural_indexes[parser.n_structural_indexes + 1] = parser.structural_indexes[parser.n_structural_indexes];
+    // This next line is critical, do not change it unless you understand what you are
+    // doing.
+    parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
+    if (simdjson_unlikely(parser.n_structural_indexes == 0u)) {
+        // We tolerate an unclosed string at the very end of the stream. Indeed, users
+        // often load their data in bulk without being careful and they want us to ignore
+        // the trailing garbage.
+        return EMPTY;
+    }
   }
   checker.check_eof();
   return checker.errors();
@@ -7347,12 +7754,12 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::walk_docum
   {
     auto value = advance();
 
-    // Make sure the outer hash or array is closed before continuing; otherwise, there are ways we
+    // Make sure the outer object or array is closed before continuing; otherwise, there are ways we
     // could get into memory corruption. See https://github.com/simdjson/simdjson/issues/906
     if (!STREAMING) {
       switch (*value) {
-        case '{': if (last_structural() != '}') { return TAPE_ERROR; }; break;
-        case '[': if (last_structural() != ']') { return TAPE_ERROR; }; break;
+        case '{': if (last_structural() != '}') { log_value("starting brace unmatched"); return TAPE_ERROR; }; break;
+        case '[': if (last_structural() != ']') { log_value("starting bracket unmatched"); return TAPE_ERROR; }; break;
       }
     }
 
@@ -7948,7 +8355,7 @@ simdjson_warn_unused error_code implementation::minify(const uint8_t *buf, size_
   return haswell::stage1::json_minifier::minify<128>(buf, len, dst, dst_len);
 }
 
-simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool streaming) noexcept {
+simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, stage1_mode streaming) noexcept {
   this->buf = _buf;
   this->len = _len;
   return haswell::stage1::json_structural_indexer::index<128>(_buf, _len, *this, streaming);
@@ -7967,7 +8374,7 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
 }
 
 simdjson_warn_unused error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {
-  auto error = stage1(_buf, _len, false);
+  auto error = stage1(_buf, _len, stage1_mode::regular);
   if (error) { return error; }
   return stage2(_doc);
 }
@@ -7997,8 +8404,10 @@ simdjson_warn_unused error_code implementation::create_dom_parser_implementation
 ) const noexcept {
   dst.reset( new (std::nothrow) dom_parser_implementation() );
   if (!dst) { return MEMALLOC; }
-  dst->set_capacity(capacity);
-  dst->set_max_depth(max_depth);
+  if (auto err = dst->set_capacity(capacity))
+    return err;
+  if (auto err = dst->set_max_depth(max_depth))
+    return err;
   return SUCCESS;
 }
 
@@ -8256,7 +8665,6 @@ using namespace simd;
         }
         this->prev_incomplete = is_incomplete(input.chunks[simd8x64<uint8_t>::NUM_CHUNKS-1]);
         this->prev_input_block = input.chunks[simd8x64<uint8_t>::NUM_CHUNKS-1];
-
       }
     }
     // do not forget to call check_eof!
@@ -8799,8 +9207,8 @@ namespace {
   *
   * Simply put, we iterate over the structural characters, starting from
   * the end. We consider that we found the end of a JSON document when the
-  * first element of the pair is NOT one of these characters: '{' '[' ';' ','
-  * and when the second element is NOT one of these characters: '}' '}' ';' ','.
+  * first element of the pair is NOT one of these characters: '{' '[' ':' ','
+  * and when the second element is NOT one of these characters: '}' ']' ':' ','.
   *
   * This simple comparison works most of the time, but it does not cover cases
   * where the batch's structural indexes contain a perfect amount of documents.
@@ -8814,7 +9222,8 @@ namespace {
   * batch.
   */
 simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementation &parser) {
-  // TODO don't count separately, just figure out depth
+  // Variant: do not count separately, just figure out depth
+  if(parser.n_structural_indexes == 0) { return 0; }
   auto arr_cnt = 0;
   auto obj_cnt = 0;
   for (auto i = parser.n_structural_indexes - 1; i > 0; i--) {
@@ -8851,6 +9260,25 @@ simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementati
     // Last document is incomplete; mark the document at i + 1 as the next one
     return i;
   }
+  // If we made it to the end, we want to finish counting to see if we have a full document.
+  switch (parser.buf[parser.structural_indexes[0]]) {
+    case '}':
+      obj_cnt--;
+      break;
+    case ']':
+      arr_cnt--;
+      break;
+    case '{':
+      obj_cnt++;
+      break;
+    case '[':
+      arr_cnt++;
+      break;
+  }
+  if (!arr_cnt && !obj_cnt) {
+    // We have a complete document.
+    return parser.n_structural_indexes;
+  }
   return 0;
 }
 
@@ -8881,8 +9309,62 @@ public:
     // it helps tremendously.
     if (bits == 0)
         return;
-    int cnt = static_cast<int>(count_ones(bits));
+#if defined(SIMDJSON_PREFER_REVERSE_BITS)
+    /**
+     * ARM lacks a fast trailing zero instruction, but it has a fast
+     * bit reversal instruction and a fast leading zero instruction.
+     * Thus it may be profitable to reverse the bits (once) and then
+     * to rely on a sequence of instructions that call the leading
+     * zero instruction.
+     *
+     * Performance notes:
+     * The chosen routine is not optimal in terms of data dependency
+     * since zero_leading_bit might require two instructions. However,
+     * it tends to minimize the total number of instructions which is
+     * beneficial.
+     */
 
+    uint64_t rev_bits = reverse_bits(bits);
+    int cnt = static_cast<int>(count_ones(bits));
+    int i = 0;
+    // Do the first 8 all together
+    for (; i<8; i++) {
+      int lz = leading_zeroes(rev_bits);
+      this->tail[i] = static_cast<uint32_t>(idx) + lz;
+      rev_bits = zero_leading_bit(rev_bits, lz);
+    }
+    // Do the next 8 all together (we hope in most cases it won't happen at all
+    // and the branch is easily predicted).
+    if (simdjson_unlikely(cnt > 8)) {
+      i = 8;
+      for (; i<16; i++) {
+        int lz = leading_zeroes(rev_bits);
+        this->tail[i] = static_cast<uint32_t>(idx) + lz;
+        rev_bits = zero_leading_bit(rev_bits, lz);
+      }
+
+
+      // Most files don't have 16+ structurals per block, so we take several basically guaranteed
+      // branch mispredictions here. 16+ structurals per block means either punctuation ({} [] , :)
+      // or the start of a value ("abc" true 123) every four characters.
+      if (simdjson_unlikely(cnt > 16)) {
+        i = 16;
+        while (rev_bits != 0) {
+          int lz = leading_zeroes(rev_bits);
+          this->tail[i++] = static_cast<uint32_t>(idx) + lz;
+          rev_bits = zero_leading_bit(rev_bits, lz);
+        }
+      }
+    }
+    this->tail += cnt;
+#else // SIMDJSON_PREFER_REVERSE_BITS
+    /**
+     * Under recent x64 systems, we often have both a fast trailing zero
+     * instruction and a fast 'clear-lower-bit' instruction so the following
+     * algorithm can be competitive.
+     */
+
+    int cnt = static_cast<int>(count_ones(bits));
     // Do the first 8 all together
     for (int i=0; i<8; i++) {
       this->tail[i] = idx + trailing_zeroes(bits);
@@ -8911,6 +9393,7 @@ public:
     }
 
     this->tail += cnt;
+#endif
   }
 };
 
@@ -8924,14 +9407,14 @@ public:
    *   you are processing substrings, you may want to call on a function like trimmed_length_safe_utf8.
    */
   template<size_t STEP_SIZE>
-  static error_code index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, bool partial) noexcept;
+  static error_code index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, stage1_mode partial) noexcept;
 
 private:
   simdjson_really_inline json_structural_indexer(uint32_t *structural_indexes);
   template<size_t STEP_SIZE>
   simdjson_really_inline void step(const uint8_t *block, buf_block_reader<STEP_SIZE> &reader) noexcept;
   simdjson_really_inline void next(const simd::simd8x64<uint8_t>& in, const json_block& block, size_t idx);
-  simdjson_really_inline error_code finish(dom_parser_implementation &parser, size_t idx, size_t len, bool partial);
+  simdjson_really_inline error_code finish(dom_parser_implementation &parser, size_t idx, size_t len, stage1_mode partial);
 
   json_scanner scanner{};
   utf8_checker checker{};
@@ -8981,10 +9464,17 @@ simdjson_really_inline size_t trim_partial_utf8(const uint8_t *buf, size_t len) 
 // workout.
 //
 template<size_t STEP_SIZE>
-error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, bool partial) noexcept {
+error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, stage1_mode partial) noexcept {
   if (simdjson_unlikely(len > parser.capacity())) { return CAPACITY; }
-  if (partial) { len = trim_partial_utf8(buf, len); }
-
+  // We guard the rest of the code so that we can assume that len > 0 throughout.
+  if (len == 0) { return EMPTY; }
+  if (is_streaming(partial)) {
+    len = trim_partial_utf8(buf, len);
+    // If you end up with an empty window after trimming
+    // the partial UTF-8 bytes, then chances are good that you
+    // have an UTF-8 formatting error.
+    if(len == 0) { return UTF8_ERROR; }
+  }
   buf_block_reader<STEP_SIZE> reader(buf, len);
   json_structural_indexer indexer(parser.structural_indexes.get());
 
@@ -8992,12 +9482,11 @@ error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_pa
   while (reader.has_full_block()) {
     indexer.step<STEP_SIZE>(reader.full_block(), reader);
   }
-
-  // Take care of the last block (will always be there unless file is empty)
+  // Take care of the last block (will always be there unless file is empty which is
+  // not supposed to happen.)
   uint8_t block[STEP_SIZE];
-  if (simdjson_unlikely(reader.get_remainder(block) == 0)) { return EMPTY; }
+  if (simdjson_unlikely(reader.get_remainder(block) == 0)) { return UNEXPECTED_ERROR; }
   indexer.step<STEP_SIZE>(block, reader);
-
   return indexer.finish(parser, reader.block_index(), len, partial);
 }
 
@@ -9028,14 +9517,13 @@ simdjson_really_inline void json_structural_indexer::next(const simd::simd8x64<u
   unescaped_chars_error |= block.non_quote_inside_string(unescaped);
 }
 
-simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_implementation &parser, size_t idx, size_t len, bool partial) {
+simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_implementation &parser, size_t idx, size_t len, stage1_mode partial) {
   // Write out the final iteration's structurals
   indexer.write(uint32_t(idx-64), prev_structurals);
-
   error_code error = scanner.finish();
   // We deliberately break down the next expression so that it is
   // human readable.
-  const bool should_we_exit =  partial ?
+  const bool should_we_exit = is_streaming(partial) ?
     ((error != SUCCESS) && (error != UNCLOSED_STRING)) // when partial we tolerate UNCLOSED_STRING
     : (error != SUCCESS); // if partial is false, we must have SUCCESS
   const bool have_unclosed_string = (error == UNCLOSED_STRING);
@@ -9044,9 +9532,10 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
   if (unescaped_chars_error) {
     return UNESCAPED_CHARS;
   }
-
   parser.n_structural_indexes = uint32_t(indexer.tail - parser.structural_indexes.get());
   /***
+   * The On Demand API requires special padding.
+   *
    * This is related to https://github.com/simdjson/simdjson/issues/906
    * Basically, we want to make sure that if the parsing continues beyond the last (valid)
    * structural character, it quickly stops.
@@ -9059,8 +9548,11 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
    * if the repeated character is [. But if so, the document must start with [. But if the document
    * starts with [, it should end with ]. If we enforce that rule, then we would get
    * ][[ which is invalid.
+   *
+   * This is illustrated with the test array_iterate_unclosed_error() on the following input:
+   * R"({ "a": [,,)"
    **/
-  parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
+  parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len); // used later in partial == stage1_mode::streaming_final
   parser.structural_indexes[parser.n_structural_indexes + 1] = uint32_t(len);
   parser.structural_indexes[parser.n_structural_indexes + 2] = 0;
   parser.next_structural_index = 0;
@@ -9071,7 +9563,7 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
   if (simdjson_unlikely(parser.structural_indexes[parser.n_structural_indexes - 1] > len)) {
     return UNEXPECTED_ERROR;
   }
-  if (partial) {
+  if (partial == stage1_mode::streaming_partial) {
     // If we have an unclosed string, then the last structural
     // will be the quote and we want to make sure to omit it.
     if(have_unclosed_string) {
@@ -9079,11 +9571,48 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
       // a valid JSON file cannot have zero structural indexes - we should have found something
       if (simdjson_unlikely(parser.n_structural_indexes == 0u)) { return CAPACITY; }
     }
+    // We truncate the input to the end of the last complete document (or zero).
     auto new_structural_indexes = find_next_document_index(parser);
     if (new_structural_indexes == 0 && parser.n_structural_indexes > 0) {
-      return CAPACITY; // If the buffer is partial but the document is incomplete, it's too big to parse.
+      if(parser.structural_indexes[0] == 0) {
+        // If the buffer is partial and we started at index 0 but the document is
+        // incomplete, it's too big to parse.
+        return CAPACITY;
+      } else {
+        // It is possible that the document could be parsed, we just had a lot
+        // of white space.
+        parser.n_structural_indexes = 0;
+        return EMPTY;
+      }
     }
+
     parser.n_structural_indexes = new_structural_indexes;
+  } else if (partial == stage1_mode::streaming_final) {
+    if(have_unclosed_string) { parser.n_structural_indexes--; }
+    // We truncate the input to the end of the last complete document (or zero).
+    // Because partial == stage1_mode::streaming_final, it means that we may
+    // silently ignore trailing garbage. Though it sounds bad, we do it
+    // deliberately because many people who have streams of JSON documents
+    // will truncate them for processing. E.g., imagine that you are uncompressing
+    // the data from a size file or receiving it in chunks from the network. You
+    // may not know where exactly the last document will be. Meanwhile the
+    // document_stream instances allow people to know the JSON documents they are
+    // parsing (see the iterator.source() method).
+    parser.n_structural_indexes = find_next_document_index(parser);
+    // We store the initial n_structural_indexes so that the client can see
+    // whether we used truncation. If initial_n_structural_indexes == parser.n_structural_indexes,
+    // then this will query parser.structural_indexes[parser.n_structural_indexes] which is len,
+    // otherwise, it will copy some prior index.
+    parser.structural_indexes[parser.n_structural_indexes + 1] = parser.structural_indexes[parser.n_structural_indexes];
+    // This next line is critical, do not change it unless you understand what you are
+    // doing.
+    parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
+    if (simdjson_unlikely(parser.n_structural_indexes == 0u)) {
+        // We tolerate an unclosed string at the very end of the stream. Indeed, users
+        // often load their data in bulk without being careful and they want us to ignore
+        // the trailing garbage.
+        return EMPTY;
+    }
   }
   checker.check_eof();
   return checker.errors();
@@ -9353,12 +9882,12 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::walk_docum
   {
     auto value = advance();
 
-    // Make sure the outer hash or array is closed before continuing; otherwise, there are ways we
+    // Make sure the outer object or array is closed before continuing; otherwise, there are ways we
     // could get into memory corruption. See https://github.com/simdjson/simdjson/issues/906
     if (!STREAMING) {
       switch (*value) {
-        case '{': if (last_structural() != '}') { return TAPE_ERROR; }; break;
-        case '[': if (last_structural() != ']') { return TAPE_ERROR; }; break;
+        case '{': if (last_structural() != '}') { log_value("starting brace unmatched"); return TAPE_ERROR; }; break;
+        case '[': if (last_structural() != ']') { log_value("starting bracket unmatched"); return TAPE_ERROR; }; break;
       }
     }
 
@@ -9956,7 +10485,7 @@ simdjson_warn_unused error_code implementation::minify(const uint8_t *buf, size_
   return ppc64::stage1::json_minifier::minify<64>(buf, len, dst, dst_len);
 }
 
-simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool streaming) noexcept {
+simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, stage1_mode streaming) noexcept {
   this->buf = _buf;
   this->len = _len;
   return ppc64::stage1::json_structural_indexer::index<64>(buf, len, *this, streaming);
@@ -9975,7 +10504,7 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
 }
 
 simdjson_warn_unused error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {
-  auto error = stage1(_buf, _len, false);
+  auto error = stage1(_buf, _len, stage1_mode::regular);
   if (error) { return error; }
   return stage2(_doc);
 }
@@ -10005,8 +10534,10 @@ simdjson_warn_unused error_code implementation::create_dom_parser_implementation
 ) const noexcept {
   dst.reset( new (std::nothrow) dom_parser_implementation() );
   if (!dst) { return MEMALLOC; }
-  dst->set_capacity(capacity);
-  dst->set_max_depth(max_depth);
+  if (auto err = dst->set_capacity(capacity))
+    return err;
+  if (auto err = dst->set_max_depth(max_depth))
+    return err;
   return SUCCESS;
 }
 
@@ -10297,7 +10828,6 @@ using namespace simd;
         }
         this->prev_incomplete = is_incomplete(input.chunks[simd8x64<uint8_t>::NUM_CHUNKS-1]);
         this->prev_input_block = input.chunks[simd8x64<uint8_t>::NUM_CHUNKS-1];
-
       }
     }
     // do not forget to call check_eof!
@@ -10840,8 +11370,8 @@ namespace {
   *
   * Simply put, we iterate over the structural characters, starting from
   * the end. We consider that we found the end of a JSON document when the
-  * first element of the pair is NOT one of these characters: '{' '[' ';' ','
-  * and when the second element is NOT one of these characters: '}' '}' ';' ','.
+  * first element of the pair is NOT one of these characters: '{' '[' ':' ','
+  * and when the second element is NOT one of these characters: '}' ']' ':' ','.
   *
   * This simple comparison works most of the time, but it does not cover cases
   * where the batch's structural indexes contain a perfect amount of documents.
@@ -10855,7 +11385,8 @@ namespace {
   * batch.
   */
 simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementation &parser) {
-  // TODO don't count separately, just figure out depth
+  // Variant: do not count separately, just figure out depth
+  if(parser.n_structural_indexes == 0) { return 0; }
   auto arr_cnt = 0;
   auto obj_cnt = 0;
   for (auto i = parser.n_structural_indexes - 1; i > 0; i--) {
@@ -10892,6 +11423,25 @@ simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementati
     // Last document is incomplete; mark the document at i + 1 as the next one
     return i;
   }
+  // If we made it to the end, we want to finish counting to see if we have a full document.
+  switch (parser.buf[parser.structural_indexes[0]]) {
+    case '}':
+      obj_cnt--;
+      break;
+    case ']':
+      arr_cnt--;
+      break;
+    case '{':
+      obj_cnt++;
+      break;
+    case '[':
+      arr_cnt++;
+      break;
+  }
+  if (!arr_cnt && !obj_cnt) {
+    // We have a complete document.
+    return parser.n_structural_indexes;
+  }
   return 0;
 }
 
@@ -10922,8 +11472,62 @@ public:
     // it helps tremendously.
     if (bits == 0)
         return;
-    int cnt = static_cast<int>(count_ones(bits));
+#if defined(SIMDJSON_PREFER_REVERSE_BITS)
+    /**
+     * ARM lacks a fast trailing zero instruction, but it has a fast
+     * bit reversal instruction and a fast leading zero instruction.
+     * Thus it may be profitable to reverse the bits (once) and then
+     * to rely on a sequence of instructions that call the leading
+     * zero instruction.
+     *
+     * Performance notes:
+     * The chosen routine is not optimal in terms of data dependency
+     * since zero_leading_bit might require two instructions. However,
+     * it tends to minimize the total number of instructions which is
+     * beneficial.
+     */
 
+    uint64_t rev_bits = reverse_bits(bits);
+    int cnt = static_cast<int>(count_ones(bits));
+    int i = 0;
+    // Do the first 8 all together
+    for (; i<8; i++) {
+      int lz = leading_zeroes(rev_bits);
+      this->tail[i] = static_cast<uint32_t>(idx) + lz;
+      rev_bits = zero_leading_bit(rev_bits, lz);
+    }
+    // Do the next 8 all together (we hope in most cases it won't happen at all
+    // and the branch is easily predicted).
+    if (simdjson_unlikely(cnt > 8)) {
+      i = 8;
+      for (; i<16; i++) {
+        int lz = leading_zeroes(rev_bits);
+        this->tail[i] = static_cast<uint32_t>(idx) + lz;
+        rev_bits = zero_leading_bit(rev_bits, lz);
+      }
+
+
+      // Most files don't have 16+ structurals per block, so we take several basically guaranteed
+      // branch mispredictions here. 16+ structurals per block means either punctuation ({} [] , :)
+      // or the start of a value ("abc" true 123) every four characters.
+      if (simdjson_unlikely(cnt > 16)) {
+        i = 16;
+        while (rev_bits != 0) {
+          int lz = leading_zeroes(rev_bits);
+          this->tail[i++] = static_cast<uint32_t>(idx) + lz;
+          rev_bits = zero_leading_bit(rev_bits, lz);
+        }
+      }
+    }
+    this->tail += cnt;
+#else // SIMDJSON_PREFER_REVERSE_BITS
+    /**
+     * Under recent x64 systems, we often have both a fast trailing zero
+     * instruction and a fast 'clear-lower-bit' instruction so the following
+     * algorithm can be competitive.
+     */
+
+    int cnt = static_cast<int>(count_ones(bits));
     // Do the first 8 all together
     for (int i=0; i<8; i++) {
       this->tail[i] = idx + trailing_zeroes(bits);
@@ -10952,6 +11556,7 @@ public:
     }
 
     this->tail += cnt;
+#endif
   }
 };
 
@@ -10965,14 +11570,14 @@ public:
    *   you are processing substrings, you may want to call on a function like trimmed_length_safe_utf8.
    */
   template<size_t STEP_SIZE>
-  static error_code index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, bool partial) noexcept;
+  static error_code index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, stage1_mode partial) noexcept;
 
 private:
   simdjson_really_inline json_structural_indexer(uint32_t *structural_indexes);
   template<size_t STEP_SIZE>
   simdjson_really_inline void step(const uint8_t *block, buf_block_reader<STEP_SIZE> &reader) noexcept;
   simdjson_really_inline void next(const simd::simd8x64<uint8_t>& in, const json_block& block, size_t idx);
-  simdjson_really_inline error_code finish(dom_parser_implementation &parser, size_t idx, size_t len, bool partial);
+  simdjson_really_inline error_code finish(dom_parser_implementation &parser, size_t idx, size_t len, stage1_mode partial);
 
   json_scanner scanner{};
   utf8_checker checker{};
@@ -11022,10 +11627,17 @@ simdjson_really_inline size_t trim_partial_utf8(const uint8_t *buf, size_t len) 
 // workout.
 //
 template<size_t STEP_SIZE>
-error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, bool partial) noexcept {
+error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, stage1_mode partial) noexcept {
   if (simdjson_unlikely(len > parser.capacity())) { return CAPACITY; }
-  if (partial) { len = trim_partial_utf8(buf, len); }
-
+  // We guard the rest of the code so that we can assume that len > 0 throughout.
+  if (len == 0) { return EMPTY; }
+  if (is_streaming(partial)) {
+    len = trim_partial_utf8(buf, len);
+    // If you end up with an empty window after trimming
+    // the partial UTF-8 bytes, then chances are good that you
+    // have an UTF-8 formatting error.
+    if(len == 0) { return UTF8_ERROR; }
+  }
   buf_block_reader<STEP_SIZE> reader(buf, len);
   json_structural_indexer indexer(parser.structural_indexes.get());
 
@@ -11033,12 +11645,11 @@ error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_pa
   while (reader.has_full_block()) {
     indexer.step<STEP_SIZE>(reader.full_block(), reader);
   }
-
-  // Take care of the last block (will always be there unless file is empty)
+  // Take care of the last block (will always be there unless file is empty which is
+  // not supposed to happen.)
   uint8_t block[STEP_SIZE];
-  if (simdjson_unlikely(reader.get_remainder(block) == 0)) { return EMPTY; }
+  if (simdjson_unlikely(reader.get_remainder(block) == 0)) { return UNEXPECTED_ERROR; }
   indexer.step<STEP_SIZE>(block, reader);
-
   return indexer.finish(parser, reader.block_index(), len, partial);
 }
 
@@ -11069,14 +11680,13 @@ simdjson_really_inline void json_structural_indexer::next(const simd::simd8x64<u
   unescaped_chars_error |= block.non_quote_inside_string(unescaped);
 }
 
-simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_implementation &parser, size_t idx, size_t len, bool partial) {
+simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_implementation &parser, size_t idx, size_t len, stage1_mode partial) {
   // Write out the final iteration's structurals
   indexer.write(uint32_t(idx-64), prev_structurals);
-
   error_code error = scanner.finish();
   // We deliberately break down the next expression so that it is
   // human readable.
-  const bool should_we_exit =  partial ?
+  const bool should_we_exit = is_streaming(partial) ?
     ((error != SUCCESS) && (error != UNCLOSED_STRING)) // when partial we tolerate UNCLOSED_STRING
     : (error != SUCCESS); // if partial is false, we must have SUCCESS
   const bool have_unclosed_string = (error == UNCLOSED_STRING);
@@ -11085,9 +11695,10 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
   if (unescaped_chars_error) {
     return UNESCAPED_CHARS;
   }
-
   parser.n_structural_indexes = uint32_t(indexer.tail - parser.structural_indexes.get());
   /***
+   * The On Demand API requires special padding.
+   *
    * This is related to https://github.com/simdjson/simdjson/issues/906
    * Basically, we want to make sure that if the parsing continues beyond the last (valid)
    * structural character, it quickly stops.
@@ -11100,8 +11711,11 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
    * if the repeated character is [. But if so, the document must start with [. But if the document
    * starts with [, it should end with ]. If we enforce that rule, then we would get
    * ][[ which is invalid.
+   *
+   * This is illustrated with the test array_iterate_unclosed_error() on the following input:
+   * R"({ "a": [,,)"
    **/
-  parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
+  parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len); // used later in partial == stage1_mode::streaming_final
   parser.structural_indexes[parser.n_structural_indexes + 1] = uint32_t(len);
   parser.structural_indexes[parser.n_structural_indexes + 2] = 0;
   parser.next_structural_index = 0;
@@ -11112,7 +11726,7 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
   if (simdjson_unlikely(parser.structural_indexes[parser.n_structural_indexes - 1] > len)) {
     return UNEXPECTED_ERROR;
   }
-  if (partial) {
+  if (partial == stage1_mode::streaming_partial) {
     // If we have an unclosed string, then the last structural
     // will be the quote and we want to make sure to omit it.
     if(have_unclosed_string) {
@@ -11120,11 +11734,48 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
       // a valid JSON file cannot have zero structural indexes - we should have found something
       if (simdjson_unlikely(parser.n_structural_indexes == 0u)) { return CAPACITY; }
     }
+    // We truncate the input to the end of the last complete document (or zero).
     auto new_structural_indexes = find_next_document_index(parser);
     if (new_structural_indexes == 0 && parser.n_structural_indexes > 0) {
-      return CAPACITY; // If the buffer is partial but the document is incomplete, it's too big to parse.
+      if(parser.structural_indexes[0] == 0) {
+        // If the buffer is partial and we started at index 0 but the document is
+        // incomplete, it's too big to parse.
+        return CAPACITY;
+      } else {
+        // It is possible that the document could be parsed, we just had a lot
+        // of white space.
+        parser.n_structural_indexes = 0;
+        return EMPTY;
+      }
     }
+
     parser.n_structural_indexes = new_structural_indexes;
+  } else if (partial == stage1_mode::streaming_final) {
+    if(have_unclosed_string) { parser.n_structural_indexes--; }
+    // We truncate the input to the end of the last complete document (or zero).
+    // Because partial == stage1_mode::streaming_final, it means that we may
+    // silently ignore trailing garbage. Though it sounds bad, we do it
+    // deliberately because many people who have streams of JSON documents
+    // will truncate them for processing. E.g., imagine that you are uncompressing
+    // the data from a size file or receiving it in chunks from the network. You
+    // may not know where exactly the last document will be. Meanwhile the
+    // document_stream instances allow people to know the JSON documents they are
+    // parsing (see the iterator.source() method).
+    parser.n_structural_indexes = find_next_document_index(parser);
+    // We store the initial n_structural_indexes so that the client can see
+    // whether we used truncation. If initial_n_structural_indexes == parser.n_structural_indexes,
+    // then this will query parser.structural_indexes[parser.n_structural_indexes] which is len,
+    // otherwise, it will copy some prior index.
+    parser.structural_indexes[parser.n_structural_indexes + 1] = parser.structural_indexes[parser.n_structural_indexes];
+    // This next line is critical, do not change it unless you understand what you are
+    // doing.
+    parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
+    if (simdjson_unlikely(parser.n_structural_indexes == 0u)) {
+        // We tolerate an unclosed string at the very end of the stream. Indeed, users
+        // often load their data in bulk without being careful and they want us to ignore
+        // the trailing garbage.
+        return EMPTY;
+    }
   }
   checker.check_eof();
   return checker.errors();
@@ -11393,12 +12044,12 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::walk_docum
   {
     auto value = advance();
 
-    // Make sure the outer hash or array is closed before continuing; otherwise, there are ways we
+    // Make sure the outer object or array is closed before continuing; otherwise, there are ways we
     // could get into memory corruption. See https://github.com/simdjson/simdjson/issues/906
     if (!STREAMING) {
       switch (*value) {
-        case '{': if (last_structural() != '}') { return TAPE_ERROR; }; break;
-        case '[': if (last_structural() != ']') { return TAPE_ERROR; }; break;
+        case '{': if (last_structural() != '}') { log_value("starting brace unmatched"); return TAPE_ERROR; }; break;
+        case '[': if (last_structural() != ']') { log_value("starting bracket unmatched"); return TAPE_ERROR; }; break;
       }
     }
 
@@ -11995,7 +12646,7 @@ simdjson_warn_unused error_code implementation::minify(const uint8_t *buf, size_
   return westmere::stage1::json_minifier::minify<64>(buf, len, dst, dst_len);
 }
 
-simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool streaming) noexcept {
+simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, stage1_mode streaming) noexcept {
   this->buf = _buf;
   this->len = _len;
   return westmere::stage1::json_structural_indexer::index<64>(_buf, _len, *this, streaming);
@@ -12014,7 +12665,7 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
 }
 
 simdjson_warn_unused error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {
-  auto error = stage1(_buf, _len, false);
+  auto error = stage1(_buf, _len, stage1_mode::regular);
   if (error) { return error; }
   return stage2(_doc);
 }

--- a/inst/include/simdjson.h
+++ b/inst/include/simdjson.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2021-03-18 11:30:40 -0400. Do not edit! */
+/* auto-generated on 2021-07-27 17:46:55 -0400. Do not edit! */
 /* begin file include/simdjson.h */
 #ifndef SIMDJSON_H
 #define SIMDJSON_H
@@ -6,7 +6,7 @@
 /**
  * @mainpage
  *
- * Check the [README.md](https://github.com/lemire/simdjson/blob/master/README.md#simdjson--parsing-gigabytes-of-json-per-second).
+ * Check the [README.md](https://github.com/simdjson/simdjson/blob/master/README.md#simdjson--parsing-gigabytes-of-json-per-second).
  *
  * Sample code. See https://github.com/simdjson/simdjson/blob/master/doc/basics.md for more examples.
 
@@ -283,6 +283,8 @@ char *to_chars(char *first, const char *last, double value);
  * Defined in src/from_chars
  */
 double from_chars(const char *first) noexcept;
+double from_chars(const char *first, const char* end) noexcept;
+
 }
 
 #ifndef SIMDJSON_EXCEPTIONS
@@ -302,7 +304,7 @@ constexpr size_t SIMDJSON_MAXSIZE_BYTES = 0xFFFFFFFF;
  * the input buf should be readable up to buf + SIMDJSON_PADDING
  * this is a stopgap; there should be a better description of the
  * main loop and its behavior that abstracts over this
- * See https://github.com/lemire/simdjson/issues/174
+ * See https://github.com/simdjson/simdjson/issues/174
  */
 constexpr size_t SIMDJSON_PADDING = 32;
 
@@ -425,7 +427,7 @@ constexpr size_t DEFAULT_MAX_DEPTH = 1024;
      * the regular visual studio or clang under visual
      * studio, you still need to handle these issues.
      *
-     * Non-Windows sytems do not have this complexity.
+     * Non-Windows systems do not have this complexity.
      */
     #if SIMDJSON_BUILDING_WINDOWS_DYNAMIC_LIBRARY
     // We set SIMDJSON_BUILDING_WINDOWS_DYNAMIC_LIBRARY when we build a DLL under Windows.
@@ -479,7 +481,7 @@ constexpr size_t DEFAULT_MAX_DEPTH = 1024;
 // now it is safe to trigger the include
 #include <string_view> // though the file is there, it does not follow that we got the implementation
 #if defined(_LIBCPP_STRING_VIEW)
-// Ah! So we under libc++ which under its Library Fundamentals Technical Specification, which preceeded C++17,
+// Ah! So we under libc++ which under its Library Fundamentals Technical Specification, which preceded C++17,
 // included string_view.
 // This means that we have string_view *even though* we may not have C++17.
 #define SIMDJSON_HAS_STRING_VIEW
@@ -2045,6 +2047,25 @@ namespace std {
 #endif
 #endif
 
+// The SIMDJSON_CHECK_EOF macro is a feature flag for the "don't require padding"
+// feature.
+
+#if SIMDJSON_CPLUSPLUS17
+// if we have C++, then fallthrough is a default attribute
+# define simdjson_fallthrough [[fallthrough]]
+// check if we have __attribute__ support
+#elif defined(__has_attribute)
+// check if we have the __fallthrough__ attribute
+#if __has_attribute(__fallthrough__)
+// we are good to go:
+# define simdjson_fallthrough                    __attribute__((__fallthrough__))
+#endif // __has_attribute(__fallthrough__)
+#endif // SIMDJSON_CPLUSPLUS17
+// on some systems, we simply do not have support for fallthrough, so use a default:
+#ifndef simdjson_fallthrough
+# define simdjson_fallthrough do {} while (0)  /* fallthrough */
+#endif // simdjson_fallthrough
+
 #endif // SIMDJSON_COMMON_DEFS_H
 /* end file include/simdjson/common_defs.h */
 
@@ -2092,33 +2113,34 @@ namespace simdjson {
  * All possible errors returned by simdjson.
  */
 enum error_code {
-  SUCCESS = 0,              ///< No error
-  CAPACITY,                 ///< This parser can't support a document that big
-  MEMALLOC,                 ///< Error allocating memory, most likely out of memory
-  TAPE_ERROR,               ///< Something went wrong while writing to the tape (stage 2), this is a generic error
-  DEPTH_ERROR,              ///< Your document exceeds the user-specified depth limitation
-  STRING_ERROR,             ///< Problem while parsing a string
-  T_ATOM_ERROR,             ///< Problem while parsing an atom starting with the letter 't'
-  F_ATOM_ERROR,             ///< Problem while parsing an atom starting with the letter 'f'
-  N_ATOM_ERROR,             ///< Problem while parsing an atom starting with the letter 'n'
-  NUMBER_ERROR,             ///< Problem while parsing a number
-  UTF8_ERROR,               ///< the input is not valid UTF-8
-  UNINITIALIZED,            ///< unknown error, or uninitialized document
-  EMPTY,                    ///< no structural element found
-  UNESCAPED_CHARS,          ///< found unescaped characters in a string.
-  UNCLOSED_STRING,          ///< missing quote at the end
-  UNSUPPORTED_ARCHITECTURE, ///< unsupported architecture
-  INCORRECT_TYPE,           ///< JSON element has a different type than user expected
-  NUMBER_OUT_OF_RANGE,      ///< JSON number does not fit in 64 bits
-  INDEX_OUT_OF_BOUNDS,      ///< JSON array index too large
-  NO_SUCH_FIELD,            ///< JSON field not found in object
-  IO_ERROR,                 ///< Error reading a file
-  INVALID_JSON_POINTER,     ///< Invalid JSON pointer reference
-  INVALID_URI_FRAGMENT,     ///< Invalid URI fragment
-  UNEXPECTED_ERROR,         ///< indicative of a bug in simdjson
-  PARSER_IN_USE,            ///< parser is already in use.
-  OUT_OF_ORDER_ITERATION,   ///< tried to iterate an array or object out of order
-  INSUFFICIENT_PADDING,     ///< The JSON doesn't have enough padding for simdjson to safely parse it.
+  SUCCESS = 0,                ///< No error
+  CAPACITY,                   ///< This parser can't support a document that big
+  MEMALLOC,                   ///< Error allocating memory, most likely out of memory
+  TAPE_ERROR,                 ///< Something went wrong while writing to the tape (stage 2), this is a generic error
+  DEPTH_ERROR,                ///< Your document exceeds the user-specified depth limitation
+  STRING_ERROR,               ///< Problem while parsing a string
+  T_ATOM_ERROR,               ///< Problem while parsing an atom starting with the letter 't'
+  F_ATOM_ERROR,               ///< Problem while parsing an atom starting with the letter 'f'
+  N_ATOM_ERROR,               ///< Problem while parsing an atom starting with the letter 'n'
+  NUMBER_ERROR,               ///< Problem while parsing a number
+  UTF8_ERROR,                 ///< the input is not valid UTF-8
+  UNINITIALIZED,              ///< unknown error, or uninitialized document
+  EMPTY,                      ///< no structural element found
+  UNESCAPED_CHARS,            ///< found unescaped characters in a string.
+  UNCLOSED_STRING,            ///< missing quote at the end
+  UNSUPPORTED_ARCHITECTURE,   ///< unsupported architecture
+  INCORRECT_TYPE,             ///< JSON element has a different type than user expected
+  NUMBER_OUT_OF_RANGE,        ///< JSON number does not fit in 64 bits
+  INDEX_OUT_OF_BOUNDS,        ///< JSON array index too large
+  NO_SUCH_FIELD,              ///< JSON field not found in object
+  IO_ERROR,                   ///< Error reading a file
+  INVALID_JSON_POINTER,       ///< Invalid JSON pointer reference
+  INVALID_URI_FRAGMENT,       ///< Invalid URI fragment
+  UNEXPECTED_ERROR,           ///< indicative of a bug in simdjson
+  PARSER_IN_USE,              ///< parser is already in use.
+  OUT_OF_ORDER_ITERATION,     ///< tried to iterate an array or object out of order
+  INSUFFICIENT_PADDING,       ///< The JSON doesn't have enough padding for simdjson to safely parse it.
+  INCOMPLETE_ARRAY_OR_OBJECT, ///< The document ends early.
   NUM_ERROR_CODES
 };
 
@@ -2262,13 +2284,13 @@ struct simdjson_result_base : protected std::pair<T, error_code> {
 
   /**
    * Get the result value. This function is safe if and only
-   * the error() method returns a value that evoluates to false.
+   * the error() method returns a value that evaluates to false.
    */
   simdjson_really_inline const T& value_unsafe() const& noexcept;
 
   /**
    * Take the result value (move it). This function is safe if and only
-   * the error() method returns a value that evoluates to false.
+   * the error() method returns a value that evaluates to false.
    */
   simdjson_really_inline T&& value_unsafe() && noexcept;
 
@@ -2353,13 +2375,13 @@ struct simdjson_result : public internal::simdjson_result_base<T> {
 
   /**
    * Get the result value. This function is safe if and only
-   * the error() method returns a value that evoluates to false.
+   * the error() method returns a value that evaluates to false.
    */
   simdjson_really_inline const T& value_unsafe() const& noexcept;
 
   /**
    * Take the result value (move it). This function is safe if and only
-   * the error() method returns a value that evoluates to false.
+   * the error() method returns a value that evaluates to false.
    */
   simdjson_really_inline T&& value_unsafe() && noexcept;
 
@@ -2369,7 +2391,6 @@ struct simdjson_result : public internal::simdjson_result_base<T> {
 
 template<typename T>
 inline std::ostream& operator<<(std::ostream& out, simdjson_result<T> value) noexcept { return out << value.value(); }
-
 #endif // SIMDJSON_EXCEPTIONS
 
 #ifndef SIMDJSON_DISABLE_DEPRECATED_API
@@ -2503,7 +2524,7 @@ struct padded_string final {
    *
    * @param path the path to the file.
    **/
-  inline static simdjson_result<padded_string> load(const std::string &path) noexcept;
+  inline static simdjson_result<padded_string> load(std::string_view path) noexcept;
 
 private:
   padded_string &operator=(const padded_string &o) = delete;
@@ -2679,7 +2700,29 @@ namespace dom {
 class document;
 } // namespace dom
 
+/**
+* This enum is used with the dom_parser_implementation::stage1 function.
+* 1) The regular mode expects a fully formed JSON document.
+* 2) The streaming_partial mode expects a possibly truncated
+* input within a stream on JSON documents.
+* 3) The stream_final mode allows us to truncate final
+* unterminated strings. It is useful in conjunction with streaming_partial.
+*/
+enum class stage1_mode { regular, streaming_partial, streaming_final};
+
+/**
+ * Returns true if mode == streaming_partial or mode == streaming_final
+ */
+inline bool is_streaming(stage1_mode mode) {
+  // performance note: it is probably faster to check that mode is different
+  // from regular than checking that it is either streaming_partial or streaming_final.
+  return (mode != stage1_mode::regular);
+  // return (mode == stage1_mode::streaming_partial || mode == stage1_mode::streaming_final);
+}
+
+
 namespace internal {
+
 
 /**
  * An implementation of simdjson's DOM parser for a particular CPU architecture.
@@ -2719,7 +2762,7 @@ public:
    * @param streaming Whether this is being called by parser::parse_many.
    * @return The error code, or SUCCESS if there was no error.
    */
-  simdjson_warn_unused virtual error_code stage1(const uint8_t *buf, size_t len, bool streaming) noexcept = 0;
+  simdjson_warn_unused virtual error_code stage1(const uint8_t *buf, size_t len, stage1_mode streaming) noexcept = 0;
 
   /**
    * @private For internal implementation use
@@ -3596,11 +3639,11 @@ inline padded_string::operator padded_string_view() const noexcept {
   return padded_string_view(data(), length(), length() + SIMDJSON_PADDING);
 }
 
-inline simdjson_result<padded_string> padded_string::load(const std::string &filename) noexcept {
+inline simdjson_result<padded_string> padded_string::load(std::string_view filename) noexcept {
   // Open the file
   SIMDJSON_PUSH_DISABLE_WARNINGS
   SIMDJSON_DISABLE_DEPRECATED_WARNING // Disable CRT_SECURE warning on MSVC: manually verified this is safe
-  std::FILE *fp = std::fopen(filename.c_str(), "rb");
+  std::FILE *fp = std::fopen(filename.data(), "rb");
   SIMDJSON_POP_DISABLE_WARNINGS
 
   if (fp == nullptr) {
@@ -4392,7 +4435,7 @@ public:
    *         - other json errors if parsing fails. You should not rely on these errors to always the same for the
    *           same document: they may vary under runtime dispatch (so they may vary depending on your system and hardware).
    */
-  inline simdjson_result<document_stream> load_many(const std::string &path, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> load_many(const std::string &path, size_t batch_size = dom::DEFAULT_BATCH_SIZE) noexcept;
 
   /**
    * Parse a buffer containing many JSON documents.
@@ -4486,18 +4529,18 @@ public:
    *         - other json errors if parsing fails. You should not rely on these errors to always the same for the
    *           same document: they may vary under runtime dispatch (so they may vary depending on your system and hardware).
    */
-  inline simdjson_result<document_stream> parse_many(const uint8_t *buf, size_t len, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> parse_many(const uint8_t *buf, size_t len, size_t batch_size = dom::DEFAULT_BATCH_SIZE) noexcept;
   /** @overload parse_many(const uint8_t *buf, size_t len, size_t batch_size) */
-  inline simdjson_result<document_stream> parse_many(const char *buf, size_t len, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> parse_many(const char *buf, size_t len, size_t batch_size = dom::DEFAULT_BATCH_SIZE) noexcept;
   /** @overload parse_many(const uint8_t *buf, size_t len, size_t batch_size) */
-  inline simdjson_result<document_stream> parse_many(const std::string &s, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> parse_many(const std::string &s, size_t batch_size = dom::DEFAULT_BATCH_SIZE) noexcept;
   inline simdjson_result<document_stream> parse_many(const std::string &&s, size_t batch_size) = delete;// unsafe
   /** @overload parse_many(const uint8_t *buf, size_t len, size_t batch_size) */
-  inline simdjson_result<document_stream> parse_many(const padded_string &s, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> parse_many(const padded_string &s, size_t batch_size = dom::DEFAULT_BATCH_SIZE) noexcept;
   inline simdjson_result<document_stream> parse_many(const padded_string &&s, size_t batch_size) = delete;// unsafe
 
   /** @private We do not want to allow implicit conversion from C string to std::string. */
-  simdjson_result<document_stream> parse_many(const char *buf, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept = delete;
+  simdjson_result<document_stream> parse_many(const char *buf, size_t batch_size = dom::DEFAULT_BATCH_SIZE) noexcept = delete;
 
   /**
    * Ensure this parser has enough memory to process JSON documents up to `capacity` bytes in length
@@ -4593,7 +4636,7 @@ public:
 
   /**
    * @private return an error code corresponding to the last parsing attempt, see
-   * simdjson.h will return UNITIALIZED if no parsing was attempted
+   * simdjson.h will return UNINITIALIZED if no parsing was attempted
    */
   [[deprecated("Use the result of parser.parse() instead")]]
   inline int get_error_code() const noexcept;
@@ -4750,7 +4793,29 @@ public:
   simdjson_really_inline document_stream &operator=(document_stream &&other) noexcept = default;
 
   simdjson_really_inline ~document_stream() noexcept;
-
+  /**
+   * Returns the input size in bytes.
+   */
+  inline size_t size_in_bytes() const noexcept;
+  /**
+   * After iterating through the stream, this method
+   * returns the number of bytes that were not parsed at the end
+   * of the stream. If truncated_bytes() differs from zero,
+   * then the input was truncated maybe because incomplete JSON
+   * documents were found at the end of the stream. You
+   * may need to process the bytes in the interval [size_in_bytes()-truncated_bytes(), size_in_bytes()).
+   *
+   * You should only call truncated_bytes() after streaming through all
+   * documents, like so:
+   *
+   *   document_stream stream = parser.parse_many(json,window);
+   *   for(auto doc : stream) {
+   *      // do something with doc
+   *   }
+   *   size_t truncated = stream.truncated_bytes();
+   *
+   */
+  inline size_t truncated_bytes() const noexcept;
   /**
    * An iterator through a forward-only stream of documents.
    */
@@ -4764,7 +4829,7 @@ public:
     using iterator_category = std::input_iterator_tag;
 
     /**
-     * Default contructor.
+     * Default constructor.
      */
     simdjson_really_inline iterator() noexcept;
     /**
@@ -4908,7 +4973,6 @@ private:
   error_code error;
   size_t batch_start{0};
   size_t doc_index{};
-
 #ifdef SIMDJSON_THREADS_ENABLED
   /** Indicates whether we use threads. Note that this needs to be a constant during the execution of the parsing. */
   bool use_thread;
@@ -5320,7 +5384,7 @@ public:
    * The key will be matched against **unescaped** JSON:
    *
    *   dom::parser parser;
-   *   parser.parse(R"({ "a\n": 1 })"_padded)["a\n"].get_uint64().first == 1
+   *   int64_t(parser.parse(R"({ "a\n": 1 })"_padded)["a\n"]) == 1
    *   parser.parse(R"({ "a\n": 1 })"_padded)["a\\n"].get_uint64().error() == NO_SUCH_FIELD
    *
    * @return The value associated with this field, or:
@@ -5335,7 +5399,7 @@ public:
    * The key will be matched against **unescaped** JSON:
    *
    *   dom::parser parser;
-   *   parser.parse(R"({ "a\n": 1 })"_padded)["a\n"].get_uint64().first == 1
+   *   int64_t(parser.parse(R"({ "a\n": 1 })"_padded)["a\n"]) == 1
    *   parser.parse(R"({ "a\n": 1 })"_padded)["a\\n"].get_uint64().error() == NO_SUCH_FIELD
    *
    * @return The value associated with this field, or:
@@ -5407,7 +5471,7 @@ public:
    * The key will be matched against **unescaped** JSON:
    *
    *   dom::parser parser;
-   *   parser.parse(R"({ "a\n": 1 })"_padded)["a\n"].get_uint64().first == 1
+   *   int64_t(parser.parse(R"({ "a\n": 1 })"_padded)["a\n"]) == 1
    *   parser.parse(R"({ "a\n": 1 })"_padded)["a\\n"].get_uint64().error() == NO_SUCH_FIELD
    *
    * @return The value associated with this field, or:
@@ -5630,7 +5694,7 @@ public:
    * The key will be matched against **unescaped** JSON:
    *
    *   dom::parser parser;
-   *   parser.parse(R"({ "a\n": 1 })"_padded)["a\n"].get_uint64().first == 1
+   *   int64_t(parser.parse(R"({ "a\n": 1 })"_padded)["a\n"]) == 1
    *   parser.parse(R"({ "a\n": 1 })"_padded)["a\\n"].get_uint64().error() == NO_SUCH_FIELD
    *
    * This function has linear-time complexity: the keys are checked one by one.
@@ -5647,7 +5711,7 @@ public:
    * The key will be matched against **unescaped** JSON:
    *
    *   dom::parser parser;
-   *   parser.parse(R"({ "a\n": 1 })"_padded)["a\n"].get_uint64().first == 1
+   *   int64_t(parser.parse(R"({ "a\n": 1 })"_padded)["a\n"]) == 1
    *   parser.parse(R"({ "a\n": 1 })"_padded)["a\\n"].get_uint64().error() == NO_SUCH_FIELD
    *
    * This function has linear-time complexity: the keys are checked one by one.
@@ -5689,7 +5753,7 @@ public:
    * The key will be matched against **unescaped** JSON:
    *
    *   dom::parser parser;
-   *   parser.parse(R"({ "a\n": 1 })"_padded)["a\n"].get_uint64().first == 1
+   *   int64_t(parser.parse(R"({ "a\n": 1 })"_padded)["a\n"]) == 1
    *   parser.parse(R"({ "a\n": 1 })"_padded)["a\\n"].get_uint64().error() == NO_SUCH_FIELD
    *
    * This function has linear-time complexity: the keys are checked one by one.
@@ -5813,7 +5877,7 @@ public:
   inline void append(simdjson::dom::element value);
   /** Append an array to the builder (to be printed) **/
   inline void append(simdjson::dom::array value);
-  /** Append an objet to the builder (to be printed) **/
+  /** Append an object to the builder (to be printed) **/
   inline void append(simdjson::dom::object value);
   /** Reset the builder (so that it would print the empty string) **/
   simdjson_really_inline void clear();
@@ -5868,7 +5932,7 @@ public:
   /** Clears out the content. **/
   simdjson_really_inline void clear();
   /**
-   * Get access to the buffer, it is own by the instance, but
+   * Get access to the buffer, it is owned by the instance, but
    * the user can make a copy.
    **/
   simdjson_really_inline std::string_view str() const;
@@ -5925,7 +5989,7 @@ inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<sim
  * Print JSON to an output stream.
  *
  * @param out The output stream.
- * @param value The objet.
+ * @param value The object.
  * @throw if there is an error with the underlying output stream. simdjson itself will not throw.
  */
 inline std::ostream& operator<<(std::ostream& out, simdjson::dom::object value)   {
@@ -6427,7 +6491,7 @@ public:
   // throughout return true if we can do the navigation, false
   // otherwise
 
-  // Withing a given scope (series of nodes at the same depth within either an
+  // Within a given scope (series of nodes at the same depth within either an
   // array or an object), we move forward.
   // Thus, given [true, null, {"a":1}, [1,2]], we would visit true, null, {
   // and [. At the object ({) or at the array ([), you can issue a "down" to
@@ -7275,7 +7339,7 @@ inline void document_stream::start() noexcept {
   // Always run the first stage 1 parse immediately
   batch_start = 0;
   error = run_stage1(*parser, batch_start);
-  if(error == EMPTY) {
+  while(error == EMPTY) {
     // In exceptional cases, we may start with an empty block
     batch_start = next_batch_start();
     if (batch_start >= len) { return; }
@@ -7292,7 +7356,6 @@ inline void document_stream::start() noexcept {
     if (error) { return; }
   }
 #endif // SIMDJSON_THREADS_ENABLED
-
   next();
 }
 
@@ -7301,13 +7364,20 @@ simdjson_really_inline size_t document_stream::iterator::current_index() const n
 }
 
 simdjson_really_inline std::string_view document_stream::iterator::source() const noexcept {
-  size_t next_doc_index = stream->batch_start + stream->parser->implementation->structural_indexes[stream->parser->implementation->next_structural_index];
-  return std::string_view(reinterpret_cast<const char*>(stream->buf) + current_index(), next_doc_index - current_index() - 1);
+  const char* start = reinterpret_cast<const char*>(stream->buf) + current_index();
+  bool object_or_array = ((*start == '[') || (*start == '{'));
+  if(object_or_array) {
+    size_t next_doc_index = stream->batch_start + stream->parser->implementation->structural_indexes[stream->parser->implementation->next_structural_index - 1];
+    return std::string_view(start, next_doc_index - current_index() + 1);
+  } else {
+    size_t next_doc_index = stream->batch_start + stream->parser->implementation->structural_indexes[stream->parser->implementation->next_structural_index];
+    return std::string_view(reinterpret_cast<const char*>(stream->buf) + current_index(), next_doc_index - current_index() - 1);
+  }
 }
 
 
 inline void document_stream::next() noexcept {
-  // We always enter at once once in an error condition.
+  // We always exit at once, once in an error condition.
   if (error) { return; }
 
   // Load the next document from the batch
@@ -7333,18 +7403,24 @@ inline void document_stream::next() noexcept {
     error = parser->implementation->stage2_next(parser->doc);
   }
 }
+inline size_t document_stream::size_in_bytes() const noexcept {
+  return len;
+}
+
+inline size_t document_stream::truncated_bytes() const noexcept {
+  return parser->implementation->structural_indexes[parser->implementation->n_structural_indexes] - parser->implementation->structural_indexes[parser->implementation->n_structural_indexes + 1];
+}
 
 inline size_t document_stream::next_batch_start() const noexcept {
   return batch_start + parser->implementation->structural_indexes[parser->implementation->n_structural_indexes];
 }
 
 inline error_code document_stream::run_stage1(dom::parser &p, size_t _batch_start) noexcept {
-  // If this is the final batch, pass partial = false
   size_t remaining = len - _batch_start;
   if (remaining <= batch_size) {
-    return p.implementation->stage1(&buf[_batch_start], remaining, false);
+    return p.implementation->stage1(&buf[_batch_start], remaining, stage1_mode::streaming_final);
   } else {
-    return p.implementation->stage1(&buf[_batch_start], batch_size, true);
+    return p.implementation->stage1(&buf[_batch_start], batch_size, stage1_mode::streaming_partial);
   }
 }
 
@@ -7450,7 +7526,7 @@ inline error_code document::allocate(size_t capacity) noexcept {
   // need a capacity of at least capacity + 1, but it is also possible to do
   // worse with "[7,7,7,7,6,7,7,7,6,7,7,6,[7,7,7,7,6,7,7,7,6,7,7,6,7,7,7,7,7,7,6"
   //where capacity + 1 tape elements are
-  // generated, see issue https://github.com/lemire/simdjson/issues/345
+  // generated, see issue https://github.com/simdjson/simdjson/issues/345
   size_t tape_capacity = SIMDJSON_ROUNDUP_N(capacity + 3, 64);
   // a document with only zero-length strings... could have capacity/3 string
   // and we would need capacity/3 * 5 bytes on the string buffer
@@ -8408,13 +8484,18 @@ inline simdjson_result<element> parser::parse_into_document(document& provided_d
   // Important: It is possible that provided_doc is actually the internal 'doc' within the parser!!!
   error_code _error = ensure_capacity(provided_doc, len);
   if (_error) { return _error; }
-  std::unique_ptr<uint8_t[]> tmp_buf;
   if (realloc_if_needed) {
-    tmp_buf.reset(reinterpret_cast<uint8_t *>( internal::allocate_padded_buffer(len) ));
-    if (tmp_buf.get() == nullptr) { return MEMALLOC; }
-    std::memcpy(static_cast<void *>(tmp_buf.get()), buf, len);
+    // Make sure we have enough capacity to copy len bytes
+    if (!loaded_bytes || _loaded_bytes_capacity < len) {
+      loaded_bytes.reset( internal::allocate_padded_buffer(len) );
+      if (!loaded_bytes) {
+        return MEMALLOC;
+      }
+      _loaded_bytes_capacity = len;
+    }
+    std::memcpy(static_cast<void *>(loaded_bytes.get()), buf, len);
   }
-  _error = implementation->parse(realloc_if_needed ? tmp_buf.get() : buf, len, provided_doc);
+  _error = implementation->parse(realloc_if_needed ? reinterpret_cast<const uint8_t*>(loaded_bytes.get()): buf, len, provided_doc);
 
   if (_error) { return _error; }
 
@@ -9332,7 +9413,7 @@ public:
   dom_parser_implementation &operator=(const dom_parser_implementation &) = delete;
 
   simdjson_warn_unused error_code parse(const uint8_t *buf, size_t len, dom::document &doc) noexcept final;
-  simdjson_warn_unused error_code stage1(const uint8_t *buf, size_t len, bool partial) noexcept final;
+  simdjson_warn_unused error_code stage1(const uint8_t *buf, size_t len, stage1_mode partial) noexcept final;
   simdjson_warn_unused error_code stage2(dom::document &doc) noexcept final;
   simdjson_warn_unused error_code stage2_next(dom::document &doc) noexcept final;
   inline simdjson_warn_unused error_code set_capacity(size_t capacity) noexcept final;
@@ -9437,6 +9518,40 @@ simdjson_really_inline int leading_zeroes(uint64_t input_num) {
 simdjson_really_inline int count_ones(uint64_t input_num) {
    return vaddv_u8(vcnt_u8(vcreate_u8(input_num)));
 }
+
+
+#if defined(__GNUC__) // catches clang and gcc
+/**
+ * ARM has a fast 64-bit "bit reversal function" that is handy. However,
+ * it is not generally available as an intrinsic function under Visual
+ * Studio (though this might be changing). Even under clang/gcc, we
+ * apparently need to invoke inline assembly.
+ */
+/*
+ * We use SIMDJSON_PREFER_REVERSE_BITS as a hint that algorithms that
+ * work well with bit reversal may use it.
+ */
+#define SIMDJSON_PREFER_REVERSE_BITS 1
+
+/* reverse the bits */
+simdjson_really_inline uint64_t reverse_bits(uint64_t input_num) {
+  uint64_t rev_bits;
+  __asm("rbit %0, %1" : "=r"(rev_bits) : "r"(input_num));
+  return rev_bits;
+}
+
+/**
+ * Flips bit at index 63 - lz. Thus if you have 'leading_zeroes' leading zeroes,
+ * then this will set to zero the leading bit. It is possible for leading_zeroes to be
+ * greating or equal to 63 in which case we trigger undefined behavior, but the output
+ * of such undefined behavior is never used.
+ **/
+NO_SANITIZE_UNDEFINED
+simdjson_really_inline uint64_t zero_leading_bit(uint64_t rev_bits, int leading_zeroes) {
+  return rev_bits ^ (uint64_t(0x8000000000000000) >> leading_zeroes);
+}
+
+#endif
 
 simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2, uint64_t *result) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
@@ -9860,7 +9975,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
     // Explicit conversion to/from unsigned
     //
     // Under Visual Studio/ARM64 uint8x16_t and int8x16_t are apparently the same type.
-    // In theory, we could check this occurence with std::same_as and std::enabled_if but it is C++14
+    // In theory, we could check this occurrence with std::same_as and std::enabled_if but it is C++14
     // and relatively ugly and hard to read.
 #ifndef SIMDJSON_REGULAR_VISUAL_STUDIO
     simdjson_really_inline explicit simd8(const uint8x16_t other): simd8(vreinterpretq_s8_u8(other)) {}
@@ -10386,7 +10501,7 @@ static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t
 } // namespace arm64
 } // namespace simdjson
 
-#define SWAR_NUMBER_PARSING
+#define SIMDJSON_SWAR_NUMBER_PARSING 1
 
 /* begin file include/simdjson/generic/numberparsing.h */
 #include <limits>
@@ -10551,8 +10666,8 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
   // Both i and power_of_five_128[index] have their most significant bit set to 1 which
   // implies that the either the most or the second most significant bit of the product
   // is 1. We pack values in this manner for efficiency reasons: it maximizes the use
-  // we make of the product. It also makes it easy to reason aboutthe product: there
-  // 0 or 1 leading zero in the product.
+  // we make of the product. It also makes it easy to reason about the product: there
+  // is 0 or 1 leading zero in the product.
 
   // Unless the least significant 9 bits of the high (64-bit) part of the full
   // product are all 1s, then we know that the most significant 55 bits are
@@ -10667,7 +10782,7 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
   mantissa &= ~(1ULL << 52);
   // we have to check that real_exponent is in range, otherwise we bail out
   if (simdjson_unlikely(real_exponent > 2046)) {
-    // We have an infinte value!!! We could actually throw an error here if we could.
+    // We have an infinite value!!! We could actually throw an error here if we could.
     return false;
   }
   d = to_double(mantissa, real_exponent, negative);
@@ -10683,6 +10798,20 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
 // one digit.
 static bool parse_float_fallback(const uint8_t *ptr, double *outDouble) {
   *outDouble = simdjson::internal::from_chars(reinterpret_cast<const char *>(ptr));
+  // We do not accept infinite values.
+
+  // Detecting finite values in a portable manner is ridiculously hard, ideally
+  // we would want to do:
+  // return !std::isfinite(*outDouble);
+  // but that mysteriously fails under legacy/old libc++ libraries, see
+  // https://github.com/simdjson/simdjson/issues/1286
+  //
+  // Therefore, fall back to this solution (the extra parens are there
+  // to handle that max may be a macro on windows).
+  return !(*outDouble > (std::numeric_limits<double>::max)() || *outDouble < std::numeric_limits<double>::lowest());
+}
+static bool parse_float_fallback(const uint8_t *ptr, const uint8_t *end_ptr, double *outDouble) {
+  *outDouble = simdjson::internal::from_chars(reinterpret_cast<const char *>(ptr), reinterpret_cast<const char *>(end_ptr));
   // We do not accept infinite values.
 
   // Detecting finite values in a portable manner is ridiculously hard, ideally
@@ -10743,14 +10872,16 @@ simdjson_really_inline error_code parse_decimal(simdjson_unused const uint8_t *c
   // the integer into a float in a lossless manner.
   const uint8_t *const first_after_period = p;
 
-#ifdef SWAR_NUMBER_PARSING
+#ifdef SIMDJSON_SWAR_NUMBER_PARSING
+#if SIMDJSON_SWAR_NUMBER_PARSING
   // this helps if we have lots of decimals!
   // this turns out to be frequent enough.
   if (is_made_of_eight_digits_fast(p)) {
     i = i * 100000000 + parse_eight_digits_unrolled(p);
     p += 8;
   }
-#endif
+#endif // SIMDJSON_SWAR_NUMBER_PARSING
+#endif // #ifdef SIMDJSON_SWAR_NUMBER_PARSING
   // Unrolling the first digit makes a small difference on some implementations (e.g. westmere)
   if (parse_digit(*p, i)) { ++p; }
   while (parse_digit(*p, i)) { p++; }
@@ -10817,9 +10948,7 @@ simdjson_really_inline size_t significant_digits(const uint8_t * start_digits, s
   // It is possible that the integer had an overflow.
   // We have to handle the case where we have 0.0000somenumber.
   const uint8_t *start = start_digits;
-  while ((*start == '0') || (*start == '.')) {
-    start++;
-  }
+  while ((*start == '0') || (*start == '.')) { ++start; }
   // we over-decrement by one when there is a '.'
   return digit_count - size_t(start - start_digits);
 }
@@ -10830,7 +10959,7 @@ simdjson_really_inline error_code write_float(const uint8_t *const src, bool neg
   // we could extend our code by using a 128-bit integer instead
   // of a 64-bit integer. However, this is uncommon in practice.
   //
-  // 9999999999999999999 < 2**64 so we can accomodate 19 digits.
+  // 9999999999999999999 < 2**64 so we can accommodate 19 digits.
   // If we have a decimal separator, then digit_count - 1 is the number of digits, but we
   // may not have a decimal separator!
   if (simdjson_unlikely(digit_count > 19 && significant_digits(start_digits, digit_count) > 19)) {
@@ -10889,6 +11018,9 @@ simdjson_really_inline error_code parse_number(const uint8_t *const, W &writer) 
 simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src) noexcept { return 0; }
 simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t * const src) noexcept { return 0; }
 simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned_in_string(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer_in_string(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double_in_string(const uint8_t * const src) noexcept { return 0; }
 
 #else
 
@@ -11099,6 +11231,104 @@ simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(
   return i;
 }
 
+
+// Parse any number from 0 to 18,446,744,073,709,551,615
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src, const uint8_t * const src_end) noexcept {
+  const uint8_t *p = src;
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // The longest positive 64-bit number is 20 digits.
+  // We do it this way so we don't trigger this branch unless we must.
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > 20))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > 20)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if ((p != src_end) && integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
+
+  if (digit_count == 20) {
+    // Positive overflow check:
+    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
+    //   biggest uint64_t.
+    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
+    //   If we got here, it's a 20 digit number starting with the digit "1".
+    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
+    //   than 1,553,255,926,290,448,384.
+    // - That is smaller than the smallest possible 20-digit number the user could write:
+    //   10,000,000,000,000,000,000.
+    // - Therefore, if the number is positive and lower than that, it's overflow.
+    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
+    //
+    if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
+  }
+
+  return i;
+}
+
+// Parse any number from 0 to 18,446,744,073,709,551,615
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned_in_string(const uint8_t * const src) noexcept {
+  const uint8_t *p = src + 1;
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while (parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // The longest positive 64-bit number is 20 digits.
+  // We do it this way so we don't trigger this branch unless we must.
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > 20))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > 20)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if (*p != '"') { return NUMBER_ERROR; }
+
+  if (digit_count == 20) {
+    // Positive overflow check:
+    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
+    //   biggest uint64_t.
+    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
+    //   If we got here, it's a 20 digit number starting with the digit "1".
+    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
+    //   than 1,553,255,926,290,448,384.
+    // - That is smaller than the smallest possible 20-digit number the user could write:
+    //   10,000,000,000,000,000,000.
+    // - Therefore, if the number is positive and lower than that, it's overflow.
+    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
+    //
+    if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
+  }
+
+  return i;
+}
+
 // Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
 simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t *src) noexcept {
   //
@@ -11118,10 +11348,10 @@ simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(co
   // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
   // Optimization note: size_t is expected to be unsigned.
   size_t digit_count = size_t(p - start_digits);
-  // The longest negative 64-bit number is 19 digits.
-  // The longest positive 64-bit number is 20 digits.
-  // We do it this way so we don't trigger this branch unless we must.
-  size_t longest_digit_count = negative ? 19 : 20;
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
   // Optimization note: the compiler can probably merge
   // ((digit_count == 0) || (digit_count > longest_digit_count))
   // into a single  branch since digit_count is unsigned.
@@ -11134,27 +11364,96 @@ simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(co
   // }
   // as a single table lookup:
   if(integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
-  if (digit_count == longest_digit_count) {
-    if (negative) {
-      // Anything negative above INT64_MAX+1 is invalid
-      if (i > uint64_t(INT64_MAX)+1) { return INCORRECT_TYPE; }
-      return ~i+1;
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
+  return negative ? (~i+1) : i;
+}
 
-    // Positive overflow check:
-    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
-    //   biggest uint64_t.
-    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
-    //   If we got here, it's a 20 digit number starting with the digit "1".
-    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
-    //   than 1,553,255,926,290,448,384.
-    // - That is smaller than the smallest possible 20-digit number the user could write:
-    //   10,000,000,000,000,000,000.
-    // - Therefore, if the number is positive and lower than that, it's overflow.
-    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
-    //
-    } else if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
-  }
+// Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t * const src, const uint8_t * const src_end) noexcept {
+  //
+  // Check for minus sign
+  //
+  if(src == src_end) { return NUMBER_ERROR; }
+  bool negative = (*src == '-');
+  const uint8_t *p = src + negative;
 
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > longest_digit_count))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > longest_digit_count)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if((p != src_end) && integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
+  return negative ? (~i+1) : i;
+}
+
+// Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer_in_string(const uint8_t *src) noexcept {
+  //
+  // Check for minus sign
+  //
+  bool negative = (*(src + 1) == '-');
+  const uint8_t *p = src + negative + 1;
+
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while (parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > longest_digit_count))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > longest_digit_count)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if(*p != '"') { return NUMBER_ERROR; }
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
   return negative ? (~i+1) : i;
 }
 
@@ -11220,6 +11519,167 @@ simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(cons
   }
 
   if (jsoncharutils::is_not_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
+
+  overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
+
+  //
+  // Assemble (or slow-parse) the float
+  //
+  double d;
+  if (simdjson_likely(!overflow)) {
+    if (compute_float_64(exponent, i, negative, d)) { return d; }
+  }
+  if (!parse_float_fallback(src-negative, &d)) {
+    return NUMBER_ERROR;
+  }
+  return d;
+}
+
+
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(const uint8_t * src, const uint8_t * const src_end) noexcept {
+  if(src == src_end) { return NUMBER_ERROR; }
+  //
+  // Check for minus sign
+  //
+  bool negative = (*src == '-');
+  src += negative;
+
+  //
+  // Parse the integer part.
+  //
+  uint64_t i = 0;
+  const uint8_t *p = src;
+  if(p == src_end) { return NUMBER_ERROR; }
+  p += parse_digit(*p, i);
+  bool leading_zero = (i == 0);
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+  // no integer digits, or 0123 (zero must be solo)
+  if ( p == src ) { return INCORRECT_TYPE; }
+  if ( (leading_zero && p != src+1)) { return NUMBER_ERROR; }
+
+  //
+  // Parse the decimal part.
+  //
+  int64_t exponent = 0;
+  bool overflow;
+  if (simdjson_likely((p != src_end) && (*p == '.'))) {
+    p++;
+    const uint8_t *start_decimal_digits = p;
+    if ((p == src_end) || !parse_digit(*p, i)) { return NUMBER_ERROR; } // no decimal digits
+    p++;
+    while ((p != src_end) && parse_digit(*p, i)) { p++; }
+    exponent = -(p - start_decimal_digits);
+
+    // Overflow check. More than 19 digits (minus the decimal) may be overflow.
+    overflow = p-src-1 > 19;
+    if (simdjson_unlikely(overflow && leading_zero)) {
+      // Skip leading 0.00000 and see if it still overflows
+      const uint8_t *start_digits = src + 2;
+      while (*start_digits == '0') { start_digits++; }
+      overflow = start_digits-src > 19;
+    }
+  } else {
+    overflow = p-src > 19;
+  }
+
+  //
+  // Parse the exponent
+  //
+  if ((p != src_end) && (*p == 'e' || *p == 'E')) {
+    p++;
+    if(p == src_end) { return NUMBER_ERROR; }
+    bool exp_neg = *p == '-';
+    p += exp_neg || *p == '+';
+
+    uint64_t exp = 0;
+    const uint8_t *start_exp_digits = p;
+    while ((p != src_end) && parse_digit(*p, exp)) { p++; }
+    // no exp digits, or 20+ exp digits
+    if (p-start_exp_digits == 0 || p-start_exp_digits > 19) { return NUMBER_ERROR; }
+
+    exponent += exp_neg ? 0-exp : exp;
+  }
+
+  if ((p != src_end) && jsoncharutils::is_not_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
+
+  overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
+
+  //
+  // Assemble (or slow-parse) the float
+  //
+  double d;
+  if (simdjson_likely(!overflow)) {
+    if (compute_float_64(exponent, i, negative, d)) { return d; }
+  }
+  if (!parse_float_fallback(src-negative, src_end, &d)) {
+    return NUMBER_ERROR;
+  }
+  return d;
+}
+
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double_in_string(const uint8_t * src) noexcept {
+  //
+  // Check for minus sign
+  //
+  bool negative = (*(src + 1) == '-');
+  src += negative + 1;
+
+  //
+  // Parse the integer part.
+  //
+  uint64_t i = 0;
+  const uint8_t *p = src;
+  p += parse_digit(*p, i);
+  bool leading_zero = (i == 0);
+  while (parse_digit(*p, i)) { p++; }
+  // no integer digits, or 0123 (zero must be solo)
+  if ( p == src ) { return INCORRECT_TYPE; }
+  if ( (leading_zero && p != src+1)) { return NUMBER_ERROR; }
+
+  //
+  // Parse the decimal part.
+  //
+  int64_t exponent = 0;
+  bool overflow;
+  if (simdjson_likely(*p == '.')) {
+    p++;
+    const uint8_t *start_decimal_digits = p;
+    if (!parse_digit(*p, i)) { return NUMBER_ERROR; } // no decimal digits
+    p++;
+    while (parse_digit(*p, i)) { p++; }
+    exponent = -(p - start_decimal_digits);
+
+    // Overflow check. More than 19 digits (minus the decimal) may be overflow.
+    overflow = p-src-1 > 19;
+    if (simdjson_unlikely(overflow && leading_zero)) {
+      // Skip leading 0.00000 and see if it still overflows
+      const uint8_t *start_digits = src + 2;
+      while (*start_digits == '0') { start_digits++; }
+      overflow = start_digits-src > 19;
+    }
+  } else {
+    overflow = p-src > 19;
+  }
+
+  //
+  // Parse the exponent
+  //
+  if (*p == 'e' || *p == 'E') {
+    p++;
+    bool exp_neg = *p == '-';
+    p += exp_neg || *p == '+';
+
+    uint64_t exp = 0;
+    const uint8_t *start_exp_digits = p;
+    while (parse_digit(*p, exp)) { p++; }
+    // no exp digits, or 20+ exp digits
+    if (p-start_exp_digits == 0 || p-start_exp_digits > 19) { return NUMBER_ERROR; }
+
+    exponent += exp_neg ? 0-exp : exp;
+  }
+
+  if (*p != '"') { return NUMBER_ERROR; }
 
   overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
 
@@ -11342,7 +11802,7 @@ public:
   dom_parser_implementation &operator=(const dom_parser_implementation &) = delete;
 
   simdjson_warn_unused error_code parse(const uint8_t *buf, size_t len, dom::document &doc) noexcept final;
-  simdjson_warn_unused error_code stage1(const uint8_t *buf, size_t len, bool partial) noexcept final;
+  simdjson_warn_unused error_code stage1(const uint8_t *buf, size_t len, stage1_mode partial) noexcept final;
   simdjson_warn_unused error_code stage2(dom::document &doc) noexcept final;
   simdjson_warn_unused error_code stage2_next(dom::document &doc) noexcept final;
   inline simdjson_warn_unused error_code set_capacity(size_t capacity) noexcept final;
@@ -11826,7 +12286,8 @@ static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t
 } // namespace fallback
 } // namespace simdjson
 
-#define SWAR_NUMBER_PARSING
+#define SIMDJSON_SWAR_NUMBER_PARSING 1
+
 /* begin file include/simdjson/generic/numberparsing.h */
 #include <limits>
 
@@ -11990,8 +12451,8 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
   // Both i and power_of_five_128[index] have their most significant bit set to 1 which
   // implies that the either the most or the second most significant bit of the product
   // is 1. We pack values in this manner for efficiency reasons: it maximizes the use
-  // we make of the product. It also makes it easy to reason aboutthe product: there
-  // 0 or 1 leading zero in the product.
+  // we make of the product. It also makes it easy to reason about the product: there
+  // is 0 or 1 leading zero in the product.
 
   // Unless the least significant 9 bits of the high (64-bit) part of the full
   // product are all 1s, then we know that the most significant 55 bits are
@@ -12106,7 +12567,7 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
   mantissa &= ~(1ULL << 52);
   // we have to check that real_exponent is in range, otherwise we bail out
   if (simdjson_unlikely(real_exponent > 2046)) {
-    // We have an infinte value!!! We could actually throw an error here if we could.
+    // We have an infinite value!!! We could actually throw an error here if we could.
     return false;
   }
   d = to_double(mantissa, real_exponent, negative);
@@ -12122,6 +12583,20 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
 // one digit.
 static bool parse_float_fallback(const uint8_t *ptr, double *outDouble) {
   *outDouble = simdjson::internal::from_chars(reinterpret_cast<const char *>(ptr));
+  // We do not accept infinite values.
+
+  // Detecting finite values in a portable manner is ridiculously hard, ideally
+  // we would want to do:
+  // return !std::isfinite(*outDouble);
+  // but that mysteriously fails under legacy/old libc++ libraries, see
+  // https://github.com/simdjson/simdjson/issues/1286
+  //
+  // Therefore, fall back to this solution (the extra parens are there
+  // to handle that max may be a macro on windows).
+  return !(*outDouble > (std::numeric_limits<double>::max)() || *outDouble < std::numeric_limits<double>::lowest());
+}
+static bool parse_float_fallback(const uint8_t *ptr, const uint8_t *end_ptr, double *outDouble) {
+  *outDouble = simdjson::internal::from_chars(reinterpret_cast<const char *>(ptr), reinterpret_cast<const char *>(end_ptr));
   // We do not accept infinite values.
 
   // Detecting finite values in a portable manner is ridiculously hard, ideally
@@ -12182,14 +12657,16 @@ simdjson_really_inline error_code parse_decimal(simdjson_unused const uint8_t *c
   // the integer into a float in a lossless manner.
   const uint8_t *const first_after_period = p;
 
-#ifdef SWAR_NUMBER_PARSING
+#ifdef SIMDJSON_SWAR_NUMBER_PARSING
+#if SIMDJSON_SWAR_NUMBER_PARSING
   // this helps if we have lots of decimals!
   // this turns out to be frequent enough.
   if (is_made_of_eight_digits_fast(p)) {
     i = i * 100000000 + parse_eight_digits_unrolled(p);
     p += 8;
   }
-#endif
+#endif // SIMDJSON_SWAR_NUMBER_PARSING
+#endif // #ifdef SIMDJSON_SWAR_NUMBER_PARSING
   // Unrolling the first digit makes a small difference on some implementations (e.g. westmere)
   if (parse_digit(*p, i)) { ++p; }
   while (parse_digit(*p, i)) { p++; }
@@ -12256,9 +12733,7 @@ simdjson_really_inline size_t significant_digits(const uint8_t * start_digits, s
   // It is possible that the integer had an overflow.
   // We have to handle the case where we have 0.0000somenumber.
   const uint8_t *start = start_digits;
-  while ((*start == '0') || (*start == '.')) {
-    start++;
-  }
+  while ((*start == '0') || (*start == '.')) { ++start; }
   // we over-decrement by one when there is a '.'
   return digit_count - size_t(start - start_digits);
 }
@@ -12269,7 +12744,7 @@ simdjson_really_inline error_code write_float(const uint8_t *const src, bool neg
   // we could extend our code by using a 128-bit integer instead
   // of a 64-bit integer. However, this is uncommon in practice.
   //
-  // 9999999999999999999 < 2**64 so we can accomodate 19 digits.
+  // 9999999999999999999 < 2**64 so we can accommodate 19 digits.
   // If we have a decimal separator, then digit_count - 1 is the number of digits, but we
   // may not have a decimal separator!
   if (simdjson_unlikely(digit_count > 19 && significant_digits(start_digits, digit_count) > 19)) {
@@ -12328,6 +12803,9 @@ simdjson_really_inline error_code parse_number(const uint8_t *const, W &writer) 
 simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src) noexcept { return 0; }
 simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t * const src) noexcept { return 0; }
 simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned_in_string(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer_in_string(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double_in_string(const uint8_t * const src) noexcept { return 0; }
 
 #else
 
@@ -12538,6 +13016,104 @@ simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(
   return i;
 }
 
+
+// Parse any number from 0 to 18,446,744,073,709,551,615
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src, const uint8_t * const src_end) noexcept {
+  const uint8_t *p = src;
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // The longest positive 64-bit number is 20 digits.
+  // We do it this way so we don't trigger this branch unless we must.
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > 20))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > 20)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if ((p != src_end) && integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
+
+  if (digit_count == 20) {
+    // Positive overflow check:
+    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
+    //   biggest uint64_t.
+    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
+    //   If we got here, it's a 20 digit number starting with the digit "1".
+    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
+    //   than 1,553,255,926,290,448,384.
+    // - That is smaller than the smallest possible 20-digit number the user could write:
+    //   10,000,000,000,000,000,000.
+    // - Therefore, if the number is positive and lower than that, it's overflow.
+    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
+    //
+    if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
+  }
+
+  return i;
+}
+
+// Parse any number from 0 to 18,446,744,073,709,551,615
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned_in_string(const uint8_t * const src) noexcept {
+  const uint8_t *p = src + 1;
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while (parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // The longest positive 64-bit number is 20 digits.
+  // We do it this way so we don't trigger this branch unless we must.
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > 20))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > 20)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if (*p != '"') { return NUMBER_ERROR; }
+
+  if (digit_count == 20) {
+    // Positive overflow check:
+    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
+    //   biggest uint64_t.
+    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
+    //   If we got here, it's a 20 digit number starting with the digit "1".
+    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
+    //   than 1,553,255,926,290,448,384.
+    // - That is smaller than the smallest possible 20-digit number the user could write:
+    //   10,000,000,000,000,000,000.
+    // - Therefore, if the number is positive and lower than that, it's overflow.
+    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
+    //
+    if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
+  }
+
+  return i;
+}
+
 // Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
 simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t *src) noexcept {
   //
@@ -12557,10 +13133,10 @@ simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(co
   // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
   // Optimization note: size_t is expected to be unsigned.
   size_t digit_count = size_t(p - start_digits);
-  // The longest negative 64-bit number is 19 digits.
-  // The longest positive 64-bit number is 20 digits.
-  // We do it this way so we don't trigger this branch unless we must.
-  size_t longest_digit_count = negative ? 19 : 20;
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
   // Optimization note: the compiler can probably merge
   // ((digit_count == 0) || (digit_count > longest_digit_count))
   // into a single  branch since digit_count is unsigned.
@@ -12573,27 +13149,96 @@ simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(co
   // }
   // as a single table lookup:
   if(integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
-  if (digit_count == longest_digit_count) {
-    if (negative) {
-      // Anything negative above INT64_MAX+1 is invalid
-      if (i > uint64_t(INT64_MAX)+1) { return INCORRECT_TYPE; }
-      return ~i+1;
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
+  return negative ? (~i+1) : i;
+}
 
-    // Positive overflow check:
-    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
-    //   biggest uint64_t.
-    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
-    //   If we got here, it's a 20 digit number starting with the digit "1".
-    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
-    //   than 1,553,255,926,290,448,384.
-    // - That is smaller than the smallest possible 20-digit number the user could write:
-    //   10,000,000,000,000,000,000.
-    // - Therefore, if the number is positive and lower than that, it's overflow.
-    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
-    //
-    } else if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
-  }
+// Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t * const src, const uint8_t * const src_end) noexcept {
+  //
+  // Check for minus sign
+  //
+  if(src == src_end) { return NUMBER_ERROR; }
+  bool negative = (*src == '-');
+  const uint8_t *p = src + negative;
 
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > longest_digit_count))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > longest_digit_count)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if((p != src_end) && integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
+  return negative ? (~i+1) : i;
+}
+
+// Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer_in_string(const uint8_t *src) noexcept {
+  //
+  // Check for minus sign
+  //
+  bool negative = (*(src + 1) == '-');
+  const uint8_t *p = src + negative + 1;
+
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while (parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > longest_digit_count))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > longest_digit_count)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if(*p != '"') { return NUMBER_ERROR; }
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
   return negative ? (~i+1) : i;
 }
 
@@ -12659,6 +13304,167 @@ simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(cons
   }
 
   if (jsoncharutils::is_not_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
+
+  overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
+
+  //
+  // Assemble (or slow-parse) the float
+  //
+  double d;
+  if (simdjson_likely(!overflow)) {
+    if (compute_float_64(exponent, i, negative, d)) { return d; }
+  }
+  if (!parse_float_fallback(src-negative, &d)) {
+    return NUMBER_ERROR;
+  }
+  return d;
+}
+
+
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(const uint8_t * src, const uint8_t * const src_end) noexcept {
+  if(src == src_end) { return NUMBER_ERROR; }
+  //
+  // Check for minus sign
+  //
+  bool negative = (*src == '-');
+  src += negative;
+
+  //
+  // Parse the integer part.
+  //
+  uint64_t i = 0;
+  const uint8_t *p = src;
+  if(p == src_end) { return NUMBER_ERROR; }
+  p += parse_digit(*p, i);
+  bool leading_zero = (i == 0);
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+  // no integer digits, or 0123 (zero must be solo)
+  if ( p == src ) { return INCORRECT_TYPE; }
+  if ( (leading_zero && p != src+1)) { return NUMBER_ERROR; }
+
+  //
+  // Parse the decimal part.
+  //
+  int64_t exponent = 0;
+  bool overflow;
+  if (simdjson_likely((p != src_end) && (*p == '.'))) {
+    p++;
+    const uint8_t *start_decimal_digits = p;
+    if ((p == src_end) || !parse_digit(*p, i)) { return NUMBER_ERROR; } // no decimal digits
+    p++;
+    while ((p != src_end) && parse_digit(*p, i)) { p++; }
+    exponent = -(p - start_decimal_digits);
+
+    // Overflow check. More than 19 digits (minus the decimal) may be overflow.
+    overflow = p-src-1 > 19;
+    if (simdjson_unlikely(overflow && leading_zero)) {
+      // Skip leading 0.00000 and see if it still overflows
+      const uint8_t *start_digits = src + 2;
+      while (*start_digits == '0') { start_digits++; }
+      overflow = start_digits-src > 19;
+    }
+  } else {
+    overflow = p-src > 19;
+  }
+
+  //
+  // Parse the exponent
+  //
+  if ((p != src_end) && (*p == 'e' || *p == 'E')) {
+    p++;
+    if(p == src_end) { return NUMBER_ERROR; }
+    bool exp_neg = *p == '-';
+    p += exp_neg || *p == '+';
+
+    uint64_t exp = 0;
+    const uint8_t *start_exp_digits = p;
+    while ((p != src_end) && parse_digit(*p, exp)) { p++; }
+    // no exp digits, or 20+ exp digits
+    if (p-start_exp_digits == 0 || p-start_exp_digits > 19) { return NUMBER_ERROR; }
+
+    exponent += exp_neg ? 0-exp : exp;
+  }
+
+  if ((p != src_end) && jsoncharutils::is_not_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
+
+  overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
+
+  //
+  // Assemble (or slow-parse) the float
+  //
+  double d;
+  if (simdjson_likely(!overflow)) {
+    if (compute_float_64(exponent, i, negative, d)) { return d; }
+  }
+  if (!parse_float_fallback(src-negative, src_end, &d)) {
+    return NUMBER_ERROR;
+  }
+  return d;
+}
+
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double_in_string(const uint8_t * src) noexcept {
+  //
+  // Check for minus sign
+  //
+  bool negative = (*(src + 1) == '-');
+  src += negative + 1;
+
+  //
+  // Parse the integer part.
+  //
+  uint64_t i = 0;
+  const uint8_t *p = src;
+  p += parse_digit(*p, i);
+  bool leading_zero = (i == 0);
+  while (parse_digit(*p, i)) { p++; }
+  // no integer digits, or 0123 (zero must be solo)
+  if ( p == src ) { return INCORRECT_TYPE; }
+  if ( (leading_zero && p != src+1)) { return NUMBER_ERROR; }
+
+  //
+  // Parse the decimal part.
+  //
+  int64_t exponent = 0;
+  bool overflow;
+  if (simdjson_likely(*p == '.')) {
+    p++;
+    const uint8_t *start_decimal_digits = p;
+    if (!parse_digit(*p, i)) { return NUMBER_ERROR; } // no decimal digits
+    p++;
+    while (parse_digit(*p, i)) { p++; }
+    exponent = -(p - start_decimal_digits);
+
+    // Overflow check. More than 19 digits (minus the decimal) may be overflow.
+    overflow = p-src-1 > 19;
+    if (simdjson_unlikely(overflow && leading_zero)) {
+      // Skip leading 0.00000 and see if it still overflows
+      const uint8_t *start_digits = src + 2;
+      while (*start_digits == '0') { start_digits++; }
+      overflow = start_digits-src > 19;
+    }
+  } else {
+    overflow = p-src > 19;
+  }
+
+  //
+  // Parse the exponent
+  //
+  if (*p == 'e' || *p == 'E') {
+    p++;
+    bool exp_neg = *p == '-';
+    p += exp_neg || *p == '+';
+
+    uint64_t exp = 0;
+    const uint8_t *start_exp_digits = p;
+    while (parse_digit(*p, exp)) { p++; }
+    // no exp digits, or 20+ exp digits
+    if (p-start_exp_digits == 0 || p-start_exp_digits > 19) { return NUMBER_ERROR; }
+
+    exponent += exp_neg ? 0-exp : exp;
+  }
+
+  if (*p != '"') { return NUMBER_ERROR; }
 
   overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
 
@@ -12846,7 +13652,7 @@ public:
   dom_parser_implementation &operator=(const dom_parser_implementation &) = delete;
 
   simdjson_warn_unused error_code parse(const uint8_t *buf, size_t len, dom::document &doc) noexcept final;
-  simdjson_warn_unused error_code stage1(const uint8_t *buf, size_t len, bool partial) noexcept final;
+  simdjson_warn_unused error_code stage1(const uint8_t *buf, size_t len, stage1_mode partial) noexcept final;
   simdjson_warn_unused error_code stage2(dom::document &doc) noexcept final;
   simdjson_warn_unused error_code stage2_next(dom::document &doc) noexcept final;
   inline simdjson_warn_unused error_code set_capacity(size_t capacity) noexcept final;
@@ -13749,7 +14555,7 @@ static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t
 } // namespace haswell
 } // namespace simdjson
 
-#define SWAR_NUMBER_PARSING
+#define SIMDJSON_SWAR_NUMBER_PARSING 1
 
 /* begin file include/simdjson/generic/numberparsing.h */
 #include <limits>
@@ -13914,8 +14720,8 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
   // Both i and power_of_five_128[index] have their most significant bit set to 1 which
   // implies that the either the most or the second most significant bit of the product
   // is 1. We pack values in this manner for efficiency reasons: it maximizes the use
-  // we make of the product. It also makes it easy to reason aboutthe product: there
-  // 0 or 1 leading zero in the product.
+  // we make of the product. It also makes it easy to reason about the product: there
+  // is 0 or 1 leading zero in the product.
 
   // Unless the least significant 9 bits of the high (64-bit) part of the full
   // product are all 1s, then we know that the most significant 55 bits are
@@ -14030,7 +14836,7 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
   mantissa &= ~(1ULL << 52);
   // we have to check that real_exponent is in range, otherwise we bail out
   if (simdjson_unlikely(real_exponent > 2046)) {
-    // We have an infinte value!!! We could actually throw an error here if we could.
+    // We have an infinite value!!! We could actually throw an error here if we could.
     return false;
   }
   d = to_double(mantissa, real_exponent, negative);
@@ -14046,6 +14852,20 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
 // one digit.
 static bool parse_float_fallback(const uint8_t *ptr, double *outDouble) {
   *outDouble = simdjson::internal::from_chars(reinterpret_cast<const char *>(ptr));
+  // We do not accept infinite values.
+
+  // Detecting finite values in a portable manner is ridiculously hard, ideally
+  // we would want to do:
+  // return !std::isfinite(*outDouble);
+  // but that mysteriously fails under legacy/old libc++ libraries, see
+  // https://github.com/simdjson/simdjson/issues/1286
+  //
+  // Therefore, fall back to this solution (the extra parens are there
+  // to handle that max may be a macro on windows).
+  return !(*outDouble > (std::numeric_limits<double>::max)() || *outDouble < std::numeric_limits<double>::lowest());
+}
+static bool parse_float_fallback(const uint8_t *ptr, const uint8_t *end_ptr, double *outDouble) {
+  *outDouble = simdjson::internal::from_chars(reinterpret_cast<const char *>(ptr), reinterpret_cast<const char *>(end_ptr));
   // We do not accept infinite values.
 
   // Detecting finite values in a portable manner is ridiculously hard, ideally
@@ -14106,14 +14926,16 @@ simdjson_really_inline error_code parse_decimal(simdjson_unused const uint8_t *c
   // the integer into a float in a lossless manner.
   const uint8_t *const first_after_period = p;
 
-#ifdef SWAR_NUMBER_PARSING
+#ifdef SIMDJSON_SWAR_NUMBER_PARSING
+#if SIMDJSON_SWAR_NUMBER_PARSING
   // this helps if we have lots of decimals!
   // this turns out to be frequent enough.
   if (is_made_of_eight_digits_fast(p)) {
     i = i * 100000000 + parse_eight_digits_unrolled(p);
     p += 8;
   }
-#endif
+#endif // SIMDJSON_SWAR_NUMBER_PARSING
+#endif // #ifdef SIMDJSON_SWAR_NUMBER_PARSING
   // Unrolling the first digit makes a small difference on some implementations (e.g. westmere)
   if (parse_digit(*p, i)) { ++p; }
   while (parse_digit(*p, i)) { p++; }
@@ -14180,9 +15002,7 @@ simdjson_really_inline size_t significant_digits(const uint8_t * start_digits, s
   // It is possible that the integer had an overflow.
   // We have to handle the case where we have 0.0000somenumber.
   const uint8_t *start = start_digits;
-  while ((*start == '0') || (*start == '.')) {
-    start++;
-  }
+  while ((*start == '0') || (*start == '.')) { ++start; }
   // we over-decrement by one when there is a '.'
   return digit_count - size_t(start - start_digits);
 }
@@ -14193,7 +15013,7 @@ simdjson_really_inline error_code write_float(const uint8_t *const src, bool neg
   // we could extend our code by using a 128-bit integer instead
   // of a 64-bit integer. However, this is uncommon in practice.
   //
-  // 9999999999999999999 < 2**64 so we can accomodate 19 digits.
+  // 9999999999999999999 < 2**64 so we can accommodate 19 digits.
   // If we have a decimal separator, then digit_count - 1 is the number of digits, but we
   // may not have a decimal separator!
   if (simdjson_unlikely(digit_count > 19 && significant_digits(start_digits, digit_count) > 19)) {
@@ -14252,6 +15072,9 @@ simdjson_really_inline error_code parse_number(const uint8_t *const, W &writer) 
 simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src) noexcept { return 0; }
 simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t * const src) noexcept { return 0; }
 simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned_in_string(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer_in_string(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double_in_string(const uint8_t * const src) noexcept { return 0; }
 
 #else
 
@@ -14462,6 +15285,104 @@ simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(
   return i;
 }
 
+
+// Parse any number from 0 to 18,446,744,073,709,551,615
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src, const uint8_t * const src_end) noexcept {
+  const uint8_t *p = src;
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // The longest positive 64-bit number is 20 digits.
+  // We do it this way so we don't trigger this branch unless we must.
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > 20))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > 20)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if ((p != src_end) && integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
+
+  if (digit_count == 20) {
+    // Positive overflow check:
+    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
+    //   biggest uint64_t.
+    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
+    //   If we got here, it's a 20 digit number starting with the digit "1".
+    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
+    //   than 1,553,255,926,290,448,384.
+    // - That is smaller than the smallest possible 20-digit number the user could write:
+    //   10,000,000,000,000,000,000.
+    // - Therefore, if the number is positive and lower than that, it's overflow.
+    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
+    //
+    if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
+  }
+
+  return i;
+}
+
+// Parse any number from 0 to 18,446,744,073,709,551,615
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned_in_string(const uint8_t * const src) noexcept {
+  const uint8_t *p = src + 1;
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while (parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // The longest positive 64-bit number is 20 digits.
+  // We do it this way so we don't trigger this branch unless we must.
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > 20))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > 20)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if (*p != '"') { return NUMBER_ERROR; }
+
+  if (digit_count == 20) {
+    // Positive overflow check:
+    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
+    //   biggest uint64_t.
+    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
+    //   If we got here, it's a 20 digit number starting with the digit "1".
+    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
+    //   than 1,553,255,926,290,448,384.
+    // - That is smaller than the smallest possible 20-digit number the user could write:
+    //   10,000,000,000,000,000,000.
+    // - Therefore, if the number is positive and lower than that, it's overflow.
+    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
+    //
+    if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
+  }
+
+  return i;
+}
+
 // Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
 simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t *src) noexcept {
   //
@@ -14481,10 +15402,10 @@ simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(co
   // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
   // Optimization note: size_t is expected to be unsigned.
   size_t digit_count = size_t(p - start_digits);
-  // The longest negative 64-bit number is 19 digits.
-  // The longest positive 64-bit number is 20 digits.
-  // We do it this way so we don't trigger this branch unless we must.
-  size_t longest_digit_count = negative ? 19 : 20;
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
   // Optimization note: the compiler can probably merge
   // ((digit_count == 0) || (digit_count > longest_digit_count))
   // into a single  branch since digit_count is unsigned.
@@ -14497,27 +15418,96 @@ simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(co
   // }
   // as a single table lookup:
   if(integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
-  if (digit_count == longest_digit_count) {
-    if (negative) {
-      // Anything negative above INT64_MAX+1 is invalid
-      if (i > uint64_t(INT64_MAX)+1) { return INCORRECT_TYPE; }
-      return ~i+1;
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
+  return negative ? (~i+1) : i;
+}
 
-    // Positive overflow check:
-    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
-    //   biggest uint64_t.
-    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
-    //   If we got here, it's a 20 digit number starting with the digit "1".
-    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
-    //   than 1,553,255,926,290,448,384.
-    // - That is smaller than the smallest possible 20-digit number the user could write:
-    //   10,000,000,000,000,000,000.
-    // - Therefore, if the number is positive and lower than that, it's overflow.
-    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
-    //
-    } else if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
-  }
+// Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t * const src, const uint8_t * const src_end) noexcept {
+  //
+  // Check for minus sign
+  //
+  if(src == src_end) { return NUMBER_ERROR; }
+  bool negative = (*src == '-');
+  const uint8_t *p = src + negative;
 
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > longest_digit_count))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > longest_digit_count)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if((p != src_end) && integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
+  return negative ? (~i+1) : i;
+}
+
+// Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer_in_string(const uint8_t *src) noexcept {
+  //
+  // Check for minus sign
+  //
+  bool negative = (*(src + 1) == '-');
+  const uint8_t *p = src + negative + 1;
+
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while (parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > longest_digit_count))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > longest_digit_count)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if(*p != '"') { return NUMBER_ERROR; }
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
   return negative ? (~i+1) : i;
 }
 
@@ -14583,6 +15573,167 @@ simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(cons
   }
 
   if (jsoncharutils::is_not_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
+
+  overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
+
+  //
+  // Assemble (or slow-parse) the float
+  //
+  double d;
+  if (simdjson_likely(!overflow)) {
+    if (compute_float_64(exponent, i, negative, d)) { return d; }
+  }
+  if (!parse_float_fallback(src-negative, &d)) {
+    return NUMBER_ERROR;
+  }
+  return d;
+}
+
+
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(const uint8_t * src, const uint8_t * const src_end) noexcept {
+  if(src == src_end) { return NUMBER_ERROR; }
+  //
+  // Check for minus sign
+  //
+  bool negative = (*src == '-');
+  src += negative;
+
+  //
+  // Parse the integer part.
+  //
+  uint64_t i = 0;
+  const uint8_t *p = src;
+  if(p == src_end) { return NUMBER_ERROR; }
+  p += parse_digit(*p, i);
+  bool leading_zero = (i == 0);
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+  // no integer digits, or 0123 (zero must be solo)
+  if ( p == src ) { return INCORRECT_TYPE; }
+  if ( (leading_zero && p != src+1)) { return NUMBER_ERROR; }
+
+  //
+  // Parse the decimal part.
+  //
+  int64_t exponent = 0;
+  bool overflow;
+  if (simdjson_likely((p != src_end) && (*p == '.'))) {
+    p++;
+    const uint8_t *start_decimal_digits = p;
+    if ((p == src_end) || !parse_digit(*p, i)) { return NUMBER_ERROR; } // no decimal digits
+    p++;
+    while ((p != src_end) && parse_digit(*p, i)) { p++; }
+    exponent = -(p - start_decimal_digits);
+
+    // Overflow check. More than 19 digits (minus the decimal) may be overflow.
+    overflow = p-src-1 > 19;
+    if (simdjson_unlikely(overflow && leading_zero)) {
+      // Skip leading 0.00000 and see if it still overflows
+      const uint8_t *start_digits = src + 2;
+      while (*start_digits == '0') { start_digits++; }
+      overflow = start_digits-src > 19;
+    }
+  } else {
+    overflow = p-src > 19;
+  }
+
+  //
+  // Parse the exponent
+  //
+  if ((p != src_end) && (*p == 'e' || *p == 'E')) {
+    p++;
+    if(p == src_end) { return NUMBER_ERROR; }
+    bool exp_neg = *p == '-';
+    p += exp_neg || *p == '+';
+
+    uint64_t exp = 0;
+    const uint8_t *start_exp_digits = p;
+    while ((p != src_end) && parse_digit(*p, exp)) { p++; }
+    // no exp digits, or 20+ exp digits
+    if (p-start_exp_digits == 0 || p-start_exp_digits > 19) { return NUMBER_ERROR; }
+
+    exponent += exp_neg ? 0-exp : exp;
+  }
+
+  if ((p != src_end) && jsoncharutils::is_not_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
+
+  overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
+
+  //
+  // Assemble (or slow-parse) the float
+  //
+  double d;
+  if (simdjson_likely(!overflow)) {
+    if (compute_float_64(exponent, i, negative, d)) { return d; }
+  }
+  if (!parse_float_fallback(src-negative, src_end, &d)) {
+    return NUMBER_ERROR;
+  }
+  return d;
+}
+
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double_in_string(const uint8_t * src) noexcept {
+  //
+  // Check for minus sign
+  //
+  bool negative = (*(src + 1) == '-');
+  src += negative + 1;
+
+  //
+  // Parse the integer part.
+  //
+  uint64_t i = 0;
+  const uint8_t *p = src;
+  p += parse_digit(*p, i);
+  bool leading_zero = (i == 0);
+  while (parse_digit(*p, i)) { p++; }
+  // no integer digits, or 0123 (zero must be solo)
+  if ( p == src ) { return INCORRECT_TYPE; }
+  if ( (leading_zero && p != src+1)) { return NUMBER_ERROR; }
+
+  //
+  // Parse the decimal part.
+  //
+  int64_t exponent = 0;
+  bool overflow;
+  if (simdjson_likely(*p == '.')) {
+    p++;
+    const uint8_t *start_decimal_digits = p;
+    if (!parse_digit(*p, i)) { return NUMBER_ERROR; } // no decimal digits
+    p++;
+    while (parse_digit(*p, i)) { p++; }
+    exponent = -(p - start_decimal_digits);
+
+    // Overflow check. More than 19 digits (minus the decimal) may be overflow.
+    overflow = p-src-1 > 19;
+    if (simdjson_unlikely(overflow && leading_zero)) {
+      // Skip leading 0.00000 and see if it still overflows
+      const uint8_t *start_digits = src + 2;
+      while (*start_digits == '0') { start_digits++; }
+      overflow = start_digits-src > 19;
+    }
+  } else {
+    overflow = p-src > 19;
+  }
+
+  //
+  // Parse the exponent
+  //
+  if (*p == 'e' || *p == 'E') {
+    p++;
+    bool exp_neg = *p == '-';
+    p += exp_neg || *p == '+';
+
+    uint64_t exp = 0;
+    const uint8_t *start_exp_digits = p;
+    while (parse_digit(*p, exp)) { p++; }
+    // no exp digits, or 20+ exp digits
+    if (p-start_exp_digits == 0 || p-start_exp_digits > 19) { return NUMBER_ERROR; }
+
+    exponent += exp_neg ? 0-exp : exp;
+  }
+
+  if (*p != '"') { return NUMBER_ERROR; }
 
   overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
 
@@ -14705,7 +15856,7 @@ public:
   dom_parser_implementation &operator=(const dom_parser_implementation &) = delete;
 
   simdjson_warn_unused error_code parse(const uint8_t *buf, size_t len, dom::document &doc) noexcept final;
-  simdjson_warn_unused error_code stage1(const uint8_t *buf, size_t len, bool partial) noexcept final;
+  simdjson_warn_unused error_code stage1(const uint8_t *buf, size_t len, stage1_mode partial) noexcept final;
   simdjson_warn_unused error_code stage2(dom::document &doc) noexcept final;
   simdjson_warn_unused error_code stage2_next(dom::document &doc) noexcept final;
   inline simdjson_warn_unused error_code set_capacity(size_t capacity) noexcept final;
@@ -15772,7 +16923,7 @@ parse_eight_digits_unrolled(const uint8_t *chars) {
 } // namespace ppc64
 } // namespace simdjson
 
-#define SWAR_NUMBER_PARSING
+#define SIMDJSON_SWAR_NUMBER_PARSING 1
 
 /* begin file include/simdjson/generic/numberparsing.h */
 #include <limits>
@@ -15937,8 +17088,8 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
   // Both i and power_of_five_128[index] have their most significant bit set to 1 which
   // implies that the either the most or the second most significant bit of the product
   // is 1. We pack values in this manner for efficiency reasons: it maximizes the use
-  // we make of the product. It also makes it easy to reason aboutthe product: there
-  // 0 or 1 leading zero in the product.
+  // we make of the product. It also makes it easy to reason about the product: there
+  // is 0 or 1 leading zero in the product.
 
   // Unless the least significant 9 bits of the high (64-bit) part of the full
   // product are all 1s, then we know that the most significant 55 bits are
@@ -16053,7 +17204,7 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
   mantissa &= ~(1ULL << 52);
   // we have to check that real_exponent is in range, otherwise we bail out
   if (simdjson_unlikely(real_exponent > 2046)) {
-    // We have an infinte value!!! We could actually throw an error here if we could.
+    // We have an infinite value!!! We could actually throw an error here if we could.
     return false;
   }
   d = to_double(mantissa, real_exponent, negative);
@@ -16069,6 +17220,20 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
 // one digit.
 static bool parse_float_fallback(const uint8_t *ptr, double *outDouble) {
   *outDouble = simdjson::internal::from_chars(reinterpret_cast<const char *>(ptr));
+  // We do not accept infinite values.
+
+  // Detecting finite values in a portable manner is ridiculously hard, ideally
+  // we would want to do:
+  // return !std::isfinite(*outDouble);
+  // but that mysteriously fails under legacy/old libc++ libraries, see
+  // https://github.com/simdjson/simdjson/issues/1286
+  //
+  // Therefore, fall back to this solution (the extra parens are there
+  // to handle that max may be a macro on windows).
+  return !(*outDouble > (std::numeric_limits<double>::max)() || *outDouble < std::numeric_limits<double>::lowest());
+}
+static bool parse_float_fallback(const uint8_t *ptr, const uint8_t *end_ptr, double *outDouble) {
+  *outDouble = simdjson::internal::from_chars(reinterpret_cast<const char *>(ptr), reinterpret_cast<const char *>(end_ptr));
   // We do not accept infinite values.
 
   // Detecting finite values in a portable manner is ridiculously hard, ideally
@@ -16129,14 +17294,16 @@ simdjson_really_inline error_code parse_decimal(simdjson_unused const uint8_t *c
   // the integer into a float in a lossless manner.
   const uint8_t *const first_after_period = p;
 
-#ifdef SWAR_NUMBER_PARSING
+#ifdef SIMDJSON_SWAR_NUMBER_PARSING
+#if SIMDJSON_SWAR_NUMBER_PARSING
   // this helps if we have lots of decimals!
   // this turns out to be frequent enough.
   if (is_made_of_eight_digits_fast(p)) {
     i = i * 100000000 + parse_eight_digits_unrolled(p);
     p += 8;
   }
-#endif
+#endif // SIMDJSON_SWAR_NUMBER_PARSING
+#endif // #ifdef SIMDJSON_SWAR_NUMBER_PARSING
   // Unrolling the first digit makes a small difference on some implementations (e.g. westmere)
   if (parse_digit(*p, i)) { ++p; }
   while (parse_digit(*p, i)) { p++; }
@@ -16203,9 +17370,7 @@ simdjson_really_inline size_t significant_digits(const uint8_t * start_digits, s
   // It is possible that the integer had an overflow.
   // We have to handle the case where we have 0.0000somenumber.
   const uint8_t *start = start_digits;
-  while ((*start == '0') || (*start == '.')) {
-    start++;
-  }
+  while ((*start == '0') || (*start == '.')) { ++start; }
   // we over-decrement by one when there is a '.'
   return digit_count - size_t(start - start_digits);
 }
@@ -16216,7 +17381,7 @@ simdjson_really_inline error_code write_float(const uint8_t *const src, bool neg
   // we could extend our code by using a 128-bit integer instead
   // of a 64-bit integer. However, this is uncommon in practice.
   //
-  // 9999999999999999999 < 2**64 so we can accomodate 19 digits.
+  // 9999999999999999999 < 2**64 so we can accommodate 19 digits.
   // If we have a decimal separator, then digit_count - 1 is the number of digits, but we
   // may not have a decimal separator!
   if (simdjson_unlikely(digit_count > 19 && significant_digits(start_digits, digit_count) > 19)) {
@@ -16275,6 +17440,9 @@ simdjson_really_inline error_code parse_number(const uint8_t *const, W &writer) 
 simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src) noexcept { return 0; }
 simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t * const src) noexcept { return 0; }
 simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned_in_string(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer_in_string(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double_in_string(const uint8_t * const src) noexcept { return 0; }
 
 #else
 
@@ -16485,6 +17653,104 @@ simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(
   return i;
 }
 
+
+// Parse any number from 0 to 18,446,744,073,709,551,615
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src, const uint8_t * const src_end) noexcept {
+  const uint8_t *p = src;
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // The longest positive 64-bit number is 20 digits.
+  // We do it this way so we don't trigger this branch unless we must.
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > 20))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > 20)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if ((p != src_end) && integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
+
+  if (digit_count == 20) {
+    // Positive overflow check:
+    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
+    //   biggest uint64_t.
+    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
+    //   If we got here, it's a 20 digit number starting with the digit "1".
+    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
+    //   than 1,553,255,926,290,448,384.
+    // - That is smaller than the smallest possible 20-digit number the user could write:
+    //   10,000,000,000,000,000,000.
+    // - Therefore, if the number is positive and lower than that, it's overflow.
+    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
+    //
+    if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
+  }
+
+  return i;
+}
+
+// Parse any number from 0 to 18,446,744,073,709,551,615
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned_in_string(const uint8_t * const src) noexcept {
+  const uint8_t *p = src + 1;
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while (parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // The longest positive 64-bit number is 20 digits.
+  // We do it this way so we don't trigger this branch unless we must.
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > 20))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > 20)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if (*p != '"') { return NUMBER_ERROR; }
+
+  if (digit_count == 20) {
+    // Positive overflow check:
+    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
+    //   biggest uint64_t.
+    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
+    //   If we got here, it's a 20 digit number starting with the digit "1".
+    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
+    //   than 1,553,255,926,290,448,384.
+    // - That is smaller than the smallest possible 20-digit number the user could write:
+    //   10,000,000,000,000,000,000.
+    // - Therefore, if the number is positive and lower than that, it's overflow.
+    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
+    //
+    if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
+  }
+
+  return i;
+}
+
 // Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
 simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t *src) noexcept {
   //
@@ -16504,10 +17770,10 @@ simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(co
   // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
   // Optimization note: size_t is expected to be unsigned.
   size_t digit_count = size_t(p - start_digits);
-  // The longest negative 64-bit number is 19 digits.
-  // The longest positive 64-bit number is 20 digits.
-  // We do it this way so we don't trigger this branch unless we must.
-  size_t longest_digit_count = negative ? 19 : 20;
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
   // Optimization note: the compiler can probably merge
   // ((digit_count == 0) || (digit_count > longest_digit_count))
   // into a single  branch since digit_count is unsigned.
@@ -16520,27 +17786,96 @@ simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(co
   // }
   // as a single table lookup:
   if(integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
-  if (digit_count == longest_digit_count) {
-    if (negative) {
-      // Anything negative above INT64_MAX+1 is invalid
-      if (i > uint64_t(INT64_MAX)+1) { return INCORRECT_TYPE; }
-      return ~i+1;
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
+  return negative ? (~i+1) : i;
+}
 
-    // Positive overflow check:
-    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
-    //   biggest uint64_t.
-    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
-    //   If we got here, it's a 20 digit number starting with the digit "1".
-    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
-    //   than 1,553,255,926,290,448,384.
-    // - That is smaller than the smallest possible 20-digit number the user could write:
-    //   10,000,000,000,000,000,000.
-    // - Therefore, if the number is positive and lower than that, it's overflow.
-    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
-    //
-    } else if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
-  }
+// Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t * const src, const uint8_t * const src_end) noexcept {
+  //
+  // Check for minus sign
+  //
+  if(src == src_end) { return NUMBER_ERROR; }
+  bool negative = (*src == '-');
+  const uint8_t *p = src + negative;
 
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > longest_digit_count))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > longest_digit_count)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if((p != src_end) && integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
+  return negative ? (~i+1) : i;
+}
+
+// Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer_in_string(const uint8_t *src) noexcept {
+  //
+  // Check for minus sign
+  //
+  bool negative = (*(src + 1) == '-');
+  const uint8_t *p = src + negative + 1;
+
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while (parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > longest_digit_count))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > longest_digit_count)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if(*p != '"') { return NUMBER_ERROR; }
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
   return negative ? (~i+1) : i;
 }
 
@@ -16606,6 +17941,167 @@ simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(cons
   }
 
   if (jsoncharutils::is_not_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
+
+  overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
+
+  //
+  // Assemble (or slow-parse) the float
+  //
+  double d;
+  if (simdjson_likely(!overflow)) {
+    if (compute_float_64(exponent, i, negative, d)) { return d; }
+  }
+  if (!parse_float_fallback(src-negative, &d)) {
+    return NUMBER_ERROR;
+  }
+  return d;
+}
+
+
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(const uint8_t * src, const uint8_t * const src_end) noexcept {
+  if(src == src_end) { return NUMBER_ERROR; }
+  //
+  // Check for minus sign
+  //
+  bool negative = (*src == '-');
+  src += negative;
+
+  //
+  // Parse the integer part.
+  //
+  uint64_t i = 0;
+  const uint8_t *p = src;
+  if(p == src_end) { return NUMBER_ERROR; }
+  p += parse_digit(*p, i);
+  bool leading_zero = (i == 0);
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+  // no integer digits, or 0123 (zero must be solo)
+  if ( p == src ) { return INCORRECT_TYPE; }
+  if ( (leading_zero && p != src+1)) { return NUMBER_ERROR; }
+
+  //
+  // Parse the decimal part.
+  //
+  int64_t exponent = 0;
+  bool overflow;
+  if (simdjson_likely((p != src_end) && (*p == '.'))) {
+    p++;
+    const uint8_t *start_decimal_digits = p;
+    if ((p == src_end) || !parse_digit(*p, i)) { return NUMBER_ERROR; } // no decimal digits
+    p++;
+    while ((p != src_end) && parse_digit(*p, i)) { p++; }
+    exponent = -(p - start_decimal_digits);
+
+    // Overflow check. More than 19 digits (minus the decimal) may be overflow.
+    overflow = p-src-1 > 19;
+    if (simdjson_unlikely(overflow && leading_zero)) {
+      // Skip leading 0.00000 and see if it still overflows
+      const uint8_t *start_digits = src + 2;
+      while (*start_digits == '0') { start_digits++; }
+      overflow = start_digits-src > 19;
+    }
+  } else {
+    overflow = p-src > 19;
+  }
+
+  //
+  // Parse the exponent
+  //
+  if ((p != src_end) && (*p == 'e' || *p == 'E')) {
+    p++;
+    if(p == src_end) { return NUMBER_ERROR; }
+    bool exp_neg = *p == '-';
+    p += exp_neg || *p == '+';
+
+    uint64_t exp = 0;
+    const uint8_t *start_exp_digits = p;
+    while ((p != src_end) && parse_digit(*p, exp)) { p++; }
+    // no exp digits, or 20+ exp digits
+    if (p-start_exp_digits == 0 || p-start_exp_digits > 19) { return NUMBER_ERROR; }
+
+    exponent += exp_neg ? 0-exp : exp;
+  }
+
+  if ((p != src_end) && jsoncharutils::is_not_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
+
+  overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
+
+  //
+  // Assemble (or slow-parse) the float
+  //
+  double d;
+  if (simdjson_likely(!overflow)) {
+    if (compute_float_64(exponent, i, negative, d)) { return d; }
+  }
+  if (!parse_float_fallback(src-negative, src_end, &d)) {
+    return NUMBER_ERROR;
+  }
+  return d;
+}
+
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double_in_string(const uint8_t * src) noexcept {
+  //
+  // Check for minus sign
+  //
+  bool negative = (*(src + 1) == '-');
+  src += negative + 1;
+
+  //
+  // Parse the integer part.
+  //
+  uint64_t i = 0;
+  const uint8_t *p = src;
+  p += parse_digit(*p, i);
+  bool leading_zero = (i == 0);
+  while (parse_digit(*p, i)) { p++; }
+  // no integer digits, or 0123 (zero must be solo)
+  if ( p == src ) { return INCORRECT_TYPE; }
+  if ( (leading_zero && p != src+1)) { return NUMBER_ERROR; }
+
+  //
+  // Parse the decimal part.
+  //
+  int64_t exponent = 0;
+  bool overflow;
+  if (simdjson_likely(*p == '.')) {
+    p++;
+    const uint8_t *start_decimal_digits = p;
+    if (!parse_digit(*p, i)) { return NUMBER_ERROR; } // no decimal digits
+    p++;
+    while (parse_digit(*p, i)) { p++; }
+    exponent = -(p - start_decimal_digits);
+
+    // Overflow check. More than 19 digits (minus the decimal) may be overflow.
+    overflow = p-src-1 > 19;
+    if (simdjson_unlikely(overflow && leading_zero)) {
+      // Skip leading 0.00000 and see if it still overflows
+      const uint8_t *start_digits = src + 2;
+      while (*start_digits == '0') { start_digits++; }
+      overflow = start_digits-src > 19;
+    }
+  } else {
+    overflow = p-src > 19;
+  }
+
+  //
+  // Parse the exponent
+  //
+  if (*p == 'e' || *p == 'E') {
+    p++;
+    bool exp_neg = *p == '-';
+    p += exp_neg || *p == '+';
+
+    uint64_t exp = 0;
+    const uint8_t *start_exp_digits = p;
+    while (parse_digit(*p, exp)) { p++; }
+    // no exp digits, or 20+ exp digits
+    if (p-start_exp_digits == 0 || p-start_exp_digits > 19) { return NUMBER_ERROR; }
+
+    exponent += exp_neg ? 0-exp : exp;
+  }
+
+  if (*p != '"') { return NUMBER_ERROR; }
 
   overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
 
@@ -16769,7 +18265,7 @@ public:
   dom_parser_implementation &operator=(const dom_parser_implementation &) = delete;
 
   simdjson_warn_unused error_code parse(const uint8_t *buf, size_t len, dom::document &doc) noexcept final;
-  simdjson_warn_unused error_code stage1(const uint8_t *buf, size_t len, bool partial) noexcept final;
+  simdjson_warn_unused error_code stage1(const uint8_t *buf, size_t len, stage1_mode partial) noexcept final;
   simdjson_warn_unused error_code stage2(dom::document &doc) noexcept final;
   simdjson_warn_unused error_code stage2_next(dom::document &doc) noexcept final;
   inline simdjson_warn_unused error_code set_capacity(size_t capacity) noexcept final;
@@ -17653,7 +19149,7 @@ static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t
 } // namespace westmere
 } // namespace simdjson
 
-#define SWAR_NUMBER_PARSING
+#define SIMDJSON_SWAR_NUMBER_PARSING 1
 
 /* begin file include/simdjson/generic/numberparsing.h */
 #include <limits>
@@ -17818,8 +19314,8 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
   // Both i and power_of_five_128[index] have their most significant bit set to 1 which
   // implies that the either the most or the second most significant bit of the product
   // is 1. We pack values in this manner for efficiency reasons: it maximizes the use
-  // we make of the product. It also makes it easy to reason aboutthe product: there
-  // 0 or 1 leading zero in the product.
+  // we make of the product. It also makes it easy to reason about the product: there
+  // is 0 or 1 leading zero in the product.
 
   // Unless the least significant 9 bits of the high (64-bit) part of the full
   // product are all 1s, then we know that the most significant 55 bits are
@@ -17934,7 +19430,7 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
   mantissa &= ~(1ULL << 52);
   // we have to check that real_exponent is in range, otherwise we bail out
   if (simdjson_unlikely(real_exponent > 2046)) {
-    // We have an infinte value!!! We could actually throw an error here if we could.
+    // We have an infinite value!!! We could actually throw an error here if we could.
     return false;
   }
   d = to_double(mantissa, real_exponent, negative);
@@ -17950,6 +19446,20 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
 // one digit.
 static bool parse_float_fallback(const uint8_t *ptr, double *outDouble) {
   *outDouble = simdjson::internal::from_chars(reinterpret_cast<const char *>(ptr));
+  // We do not accept infinite values.
+
+  // Detecting finite values in a portable manner is ridiculously hard, ideally
+  // we would want to do:
+  // return !std::isfinite(*outDouble);
+  // but that mysteriously fails under legacy/old libc++ libraries, see
+  // https://github.com/simdjson/simdjson/issues/1286
+  //
+  // Therefore, fall back to this solution (the extra parens are there
+  // to handle that max may be a macro on windows).
+  return !(*outDouble > (std::numeric_limits<double>::max)() || *outDouble < std::numeric_limits<double>::lowest());
+}
+static bool parse_float_fallback(const uint8_t *ptr, const uint8_t *end_ptr, double *outDouble) {
+  *outDouble = simdjson::internal::from_chars(reinterpret_cast<const char *>(ptr), reinterpret_cast<const char *>(end_ptr));
   // We do not accept infinite values.
 
   // Detecting finite values in a portable manner is ridiculously hard, ideally
@@ -18010,14 +19520,16 @@ simdjson_really_inline error_code parse_decimal(simdjson_unused const uint8_t *c
   // the integer into a float in a lossless manner.
   const uint8_t *const first_after_period = p;
 
-#ifdef SWAR_NUMBER_PARSING
+#ifdef SIMDJSON_SWAR_NUMBER_PARSING
+#if SIMDJSON_SWAR_NUMBER_PARSING
   // this helps if we have lots of decimals!
   // this turns out to be frequent enough.
   if (is_made_of_eight_digits_fast(p)) {
     i = i * 100000000 + parse_eight_digits_unrolled(p);
     p += 8;
   }
-#endif
+#endif // SIMDJSON_SWAR_NUMBER_PARSING
+#endif // #ifdef SIMDJSON_SWAR_NUMBER_PARSING
   // Unrolling the first digit makes a small difference on some implementations (e.g. westmere)
   if (parse_digit(*p, i)) { ++p; }
   while (parse_digit(*p, i)) { p++; }
@@ -18084,9 +19596,7 @@ simdjson_really_inline size_t significant_digits(const uint8_t * start_digits, s
   // It is possible that the integer had an overflow.
   // We have to handle the case where we have 0.0000somenumber.
   const uint8_t *start = start_digits;
-  while ((*start == '0') || (*start == '.')) {
-    start++;
-  }
+  while ((*start == '0') || (*start == '.')) { ++start; }
   // we over-decrement by one when there is a '.'
   return digit_count - size_t(start - start_digits);
 }
@@ -18097,7 +19607,7 @@ simdjson_really_inline error_code write_float(const uint8_t *const src, bool neg
   // we could extend our code by using a 128-bit integer instead
   // of a 64-bit integer. However, this is uncommon in practice.
   //
-  // 9999999999999999999 < 2**64 so we can accomodate 19 digits.
+  // 9999999999999999999 < 2**64 so we can accommodate 19 digits.
   // If we have a decimal separator, then digit_count - 1 is the number of digits, but we
   // may not have a decimal separator!
   if (simdjson_unlikely(digit_count > 19 && significant_digits(start_digits, digit_count) > 19)) {
@@ -18156,6 +19666,9 @@ simdjson_really_inline error_code parse_number(const uint8_t *const, W &writer) 
 simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src) noexcept { return 0; }
 simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t * const src) noexcept { return 0; }
 simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned_in_string(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer_in_string(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double_in_string(const uint8_t * const src) noexcept { return 0; }
 
 #else
 
@@ -18366,6 +19879,104 @@ simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(
   return i;
 }
 
+
+// Parse any number from 0 to 18,446,744,073,709,551,615
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src, const uint8_t * const src_end) noexcept {
+  const uint8_t *p = src;
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // The longest positive 64-bit number is 20 digits.
+  // We do it this way so we don't trigger this branch unless we must.
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > 20))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > 20)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if ((p != src_end) && integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
+
+  if (digit_count == 20) {
+    // Positive overflow check:
+    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
+    //   biggest uint64_t.
+    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
+    //   If we got here, it's a 20 digit number starting with the digit "1".
+    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
+    //   than 1,553,255,926,290,448,384.
+    // - That is smaller than the smallest possible 20-digit number the user could write:
+    //   10,000,000,000,000,000,000.
+    // - Therefore, if the number is positive and lower than that, it's overflow.
+    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
+    //
+    if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
+  }
+
+  return i;
+}
+
+// Parse any number from 0 to 18,446,744,073,709,551,615
+simdjson_unused simdjson_really_inline simdjson_result<uint64_t> parse_unsigned_in_string(const uint8_t * const src) noexcept {
+  const uint8_t *p = src + 1;
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while (parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // The longest positive 64-bit number is 20 digits.
+  // We do it this way so we don't trigger this branch unless we must.
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > 20))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > 20)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if (*p != '"') { return NUMBER_ERROR; }
+
+  if (digit_count == 20) {
+    // Positive overflow check:
+    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
+    //   biggest uint64_t.
+    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
+    //   If we got here, it's a 20 digit number starting with the digit "1".
+    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
+    //   than 1,553,255,926,290,448,384.
+    // - That is smaller than the smallest possible 20-digit number the user could write:
+    //   10,000,000,000,000,000,000.
+    // - Therefore, if the number is positive and lower than that, it's overflow.
+    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
+    //
+    if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
+  }
+
+  return i;
+}
+
 // Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
 simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t *src) noexcept {
   //
@@ -18385,10 +19996,10 @@ simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(co
   // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
   // Optimization note: size_t is expected to be unsigned.
   size_t digit_count = size_t(p - start_digits);
-  // The longest negative 64-bit number is 19 digits.
-  // The longest positive 64-bit number is 20 digits.
-  // We do it this way so we don't trigger this branch unless we must.
-  size_t longest_digit_count = negative ? 19 : 20;
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
   // Optimization note: the compiler can probably merge
   // ((digit_count == 0) || (digit_count > longest_digit_count))
   // into a single  branch since digit_count is unsigned.
@@ -18401,27 +20012,96 @@ simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(co
   // }
   // as a single table lookup:
   if(integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
-  if (digit_count == longest_digit_count) {
-    if (negative) {
-      // Anything negative above INT64_MAX+1 is invalid
-      if (i > uint64_t(INT64_MAX)+1) { return INCORRECT_TYPE; }
-      return ~i+1;
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
+  return negative ? (~i+1) : i;
+}
 
-    // Positive overflow check:
-    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
-    //   biggest uint64_t.
-    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
-    //   If we got here, it's a 20 digit number starting with the digit "1".
-    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
-    //   than 1,553,255,926,290,448,384.
-    // - That is smaller than the smallest possible 20-digit number the user could write:
-    //   10,000,000,000,000,000,000.
-    // - Therefore, if the number is positive and lower than that, it's overflow.
-    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
-    //
-    } else if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
-  }
+// Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t * const src, const uint8_t * const src_end) noexcept {
+  //
+  // Check for minus sign
+  //
+  if(src == src_end) { return NUMBER_ERROR; }
+  bool negative = (*src == '-');
+  const uint8_t *p = src + negative;
 
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > longest_digit_count))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > longest_digit_count)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if((p != src_end) && integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
+  return negative ? (~i+1) : i;
+}
+
+// Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+simdjson_unused simdjson_really_inline simdjson_result<int64_t> parse_integer_in_string(const uint8_t *src) noexcept {
+  //
+  // Check for minus sign
+  //
+  bool negative = (*(src + 1) == '-');
+  const uint8_t *p = src + negative + 1;
+
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while (parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  // Optimization note: size_t is expected to be unsigned.
+  size_t digit_count = size_t(p - start_digits);
+  // We go from
+  // -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+  // so we can never represent numbers that have more than 19 digits.
+  size_t longest_digit_count = 19;
+  // Optimization note: the compiler can probably merge
+  // ((digit_count == 0) || (digit_count > longest_digit_count))
+  // into a single  branch since digit_count is unsigned.
+  if ((digit_count == 0) || (digit_count > longest_digit_count)) { return INCORRECT_TYPE; }
+  // Here digit_count > 0.
+  if (('0' == *start_digits) && (digit_count > 1)) { return NUMBER_ERROR; }
+  // We can do the following...
+  // if (!jsoncharutils::is_structural_or_whitespace(*p)) {
+  //  return (*p == '.' || *p == 'e' || *p == 'E') ? INCORRECT_TYPE : NUMBER_ERROR;
+  // }
+  // as a single table lookup:
+  if(*p != '"') { return NUMBER_ERROR; }
+  // Negative numbers have can go down to - INT64_MAX - 1 whereas positive numbers are limited to INT64_MAX.
+  // Performance note: This check is only needed when digit_count == longest_digit_count but it is
+  // so cheap that we might as well always make it.
+  if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
   return negative ? (~i+1) : i;
 }
 
@@ -18487,6 +20167,167 @@ simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(cons
   }
 
   if (jsoncharutils::is_not_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
+
+  overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
+
+  //
+  // Assemble (or slow-parse) the float
+  //
+  double d;
+  if (simdjson_likely(!overflow)) {
+    if (compute_float_64(exponent, i, negative, d)) { return d; }
+  }
+  if (!parse_float_fallback(src-negative, &d)) {
+    return NUMBER_ERROR;
+  }
+  return d;
+}
+
+
+// Never read at src_end or beyond
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double(const uint8_t * src, const uint8_t * const src_end) noexcept {
+  if(src == src_end) { return NUMBER_ERROR; }
+  //
+  // Check for minus sign
+  //
+  bool negative = (*src == '-');
+  src += negative;
+
+  //
+  // Parse the integer part.
+  //
+  uint64_t i = 0;
+  const uint8_t *p = src;
+  if(p == src_end) { return NUMBER_ERROR; }
+  p += parse_digit(*p, i);
+  bool leading_zero = (i == 0);
+  while ((p != src_end) && parse_digit(*p, i)) { p++; }
+  // no integer digits, or 0123 (zero must be solo)
+  if ( p == src ) { return INCORRECT_TYPE; }
+  if ( (leading_zero && p != src+1)) { return NUMBER_ERROR; }
+
+  //
+  // Parse the decimal part.
+  //
+  int64_t exponent = 0;
+  bool overflow;
+  if (simdjson_likely((p != src_end) && (*p == '.'))) {
+    p++;
+    const uint8_t *start_decimal_digits = p;
+    if ((p == src_end) || !parse_digit(*p, i)) { return NUMBER_ERROR; } // no decimal digits
+    p++;
+    while ((p != src_end) && parse_digit(*p, i)) { p++; }
+    exponent = -(p - start_decimal_digits);
+
+    // Overflow check. More than 19 digits (minus the decimal) may be overflow.
+    overflow = p-src-1 > 19;
+    if (simdjson_unlikely(overflow && leading_zero)) {
+      // Skip leading 0.00000 and see if it still overflows
+      const uint8_t *start_digits = src + 2;
+      while (*start_digits == '0') { start_digits++; }
+      overflow = start_digits-src > 19;
+    }
+  } else {
+    overflow = p-src > 19;
+  }
+
+  //
+  // Parse the exponent
+  //
+  if ((p != src_end) && (*p == 'e' || *p == 'E')) {
+    p++;
+    if(p == src_end) { return NUMBER_ERROR; }
+    bool exp_neg = *p == '-';
+    p += exp_neg || *p == '+';
+
+    uint64_t exp = 0;
+    const uint8_t *start_exp_digits = p;
+    while ((p != src_end) && parse_digit(*p, exp)) { p++; }
+    // no exp digits, or 20+ exp digits
+    if (p-start_exp_digits == 0 || p-start_exp_digits > 19) { return NUMBER_ERROR; }
+
+    exponent += exp_neg ? 0-exp : exp;
+  }
+
+  if ((p != src_end) && jsoncharutils::is_not_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
+
+  overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
+
+  //
+  // Assemble (or slow-parse) the float
+  //
+  double d;
+  if (simdjson_likely(!overflow)) {
+    if (compute_float_64(exponent, i, negative, d)) { return d; }
+  }
+  if (!parse_float_fallback(src-negative, src_end, &d)) {
+    return NUMBER_ERROR;
+  }
+  return d;
+}
+
+simdjson_unused simdjson_really_inline simdjson_result<double> parse_double_in_string(const uint8_t * src) noexcept {
+  //
+  // Check for minus sign
+  //
+  bool negative = (*(src + 1) == '-');
+  src += negative + 1;
+
+  //
+  // Parse the integer part.
+  //
+  uint64_t i = 0;
+  const uint8_t *p = src;
+  p += parse_digit(*p, i);
+  bool leading_zero = (i == 0);
+  while (parse_digit(*p, i)) { p++; }
+  // no integer digits, or 0123 (zero must be solo)
+  if ( p == src ) { return INCORRECT_TYPE; }
+  if ( (leading_zero && p != src+1)) { return NUMBER_ERROR; }
+
+  //
+  // Parse the decimal part.
+  //
+  int64_t exponent = 0;
+  bool overflow;
+  if (simdjson_likely(*p == '.')) {
+    p++;
+    const uint8_t *start_decimal_digits = p;
+    if (!parse_digit(*p, i)) { return NUMBER_ERROR; } // no decimal digits
+    p++;
+    while (parse_digit(*p, i)) { p++; }
+    exponent = -(p - start_decimal_digits);
+
+    // Overflow check. More than 19 digits (minus the decimal) may be overflow.
+    overflow = p-src-1 > 19;
+    if (simdjson_unlikely(overflow && leading_zero)) {
+      // Skip leading 0.00000 and see if it still overflows
+      const uint8_t *start_digits = src + 2;
+      while (*start_digits == '0') { start_digits++; }
+      overflow = start_digits-src > 19;
+    }
+  } else {
+    overflow = p-src > 19;
+  }
+
+  //
+  // Parse the exponent
+  //
+  if (*p == 'e' || *p == 'E') {
+    p++;
+    bool exp_neg = *p == '-';
+    p += exp_neg || *p == '+';
+
+    uint64_t exp = 0;
+    const uint8_t *start_exp_digits = p;
+    while (parse_digit(*p, exp)) { p++; }
+    // no exp digits, or 20+ exp digits
+    if (p-start_exp_digits == 0 || p-start_exp_digits > 19) { return NUMBER_ERROR; }
+
+    exponent += exp_neg ? 0-exp : exp;
+  }
+
+  if (*p != '"') { return NUMBER_ERROR; }
 
   overflow = overflow || exponent < simdjson::internal::smallest_power || exponent > simdjson::internal::largest_power;
 
@@ -18651,19 +20492,24 @@ struct implementation_simdjson_result_base {
    */
   simdjson_really_inline operator T&&() && noexcept(false);
 
-  /**
-   * Get the result value. This function is safe if and only
-   * the error() method returns a value that evoluates to false.
-   */
-  simdjson_really_inline const T& value_unsafe() const& noexcept;
-
-  /**
-   * Take the result value (move it). This function is safe if and only
-   * the error() method returns a value that evoluates to false.
-   */
-  simdjson_really_inline T&& value_unsafe() && noexcept;
 
 #endif // SIMDJSON_EXCEPTIONS
+
+  /**
+   * Get the result value. This function is safe if and only
+   * the error() method returns a value that evaluates to false.
+   */
+  simdjson_really_inline const T& value_unsafe() const& noexcept;
+  /**
+   * Get the result value. This function is safe if and only
+   * the error() method returns a value that evaluates to false.
+   */
+  simdjson_really_inline T& value_unsafe() & noexcept;
+  /**
+   * Take the result value (move it). This function is safe if and only
+   * the error() method returns a value that evaluates to false.
+   */
+  simdjson_really_inline T&& value_unsafe() && noexcept;
 
   T first{};
   error_code second{UNINITIALIZED};
@@ -18773,23 +20619,26 @@ namespace logger {
   static constexpr const bool LOG_ENABLED = false;
 #endif
 
-static simdjson_really_inline void log_headers() noexcept;
-static simdjson_really_inline void log_line(const json_iterator &iter, token_position index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept;
-static simdjson_really_inline void log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
-static simdjson_really_inline void log_event(const json_iterator &iter, const char *type, std::string_view detail="", int delta=0, int depth_delta=0) noexcept;
-static simdjson_really_inline void log_value(const json_iterator &iter, token_position index, depth_t depth, const char *type, std::string_view detail="") noexcept;
-static simdjson_really_inline void log_value(const json_iterator &iter, const char *type, std::string_view detail="", int delta=-1, int depth_delta=0) noexcept;
-static simdjson_really_inline void log_start_value(const json_iterator &iter, token_position index, depth_t depth, const char *type, std::string_view detail="") noexcept;
-static simdjson_really_inline void log_start_value(const json_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
-static simdjson_really_inline void log_end_value(const json_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
-static simdjson_really_inline void log_error(const json_iterator &iter, token_position index, depth_t depth, const char *error, const char *detail="") noexcept;
-static simdjson_really_inline void log_error(const json_iterator &iter, const char *error, const char *detail="", int delta=-1, int depth_delta=0) noexcept;
+// We do not want these functions to be 'really inlined' since real inlining is
+// for performance purposes and if you are using the loggers, you do not care about
+// performance (or should not).
+static inline void log_headers() noexcept;
+static inline void log_line(const json_iterator &iter, token_position index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept;
+static inline void log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
+static inline void log_event(const json_iterator &iter, const char *type, std::string_view detail="", int delta=0, int depth_delta=0) noexcept;
+static inline void log_value(const json_iterator &iter, token_position index, depth_t depth, const char *type, std::string_view detail="") noexcept;
+static inline void log_value(const json_iterator &iter, const char *type, std::string_view detail="", int delta=-1, int depth_delta=0) noexcept;
+static inline void log_start_value(const json_iterator &iter, token_position index, depth_t depth, const char *type, std::string_view detail="") noexcept;
+static inline void log_start_value(const json_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
+static inline void log_end_value(const json_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
+static inline void log_error(const json_iterator &iter, token_position index, depth_t depth, const char *error, const char *detail="") noexcept;
+static inline void log_error(const json_iterator &iter, const char *error, const char *detail="", int delta=-1, int depth_delta=0) noexcept;
 
-static simdjson_really_inline void log_event(const value_iterator &iter, const char *type, std::string_view detail="", int delta=0, int depth_delta=0) noexcept;
-static simdjson_really_inline void log_value(const value_iterator &iter, const char *type, std::string_view detail="", int delta=-1, int depth_delta=0) noexcept;
-static simdjson_really_inline void log_start_value(const value_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
-static simdjson_really_inline void log_end_value(const value_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
-static simdjson_really_inline void log_error(const value_iterator &iter, const char *error, const char *detail="", int delta=-1, int depth_delta=0) noexcept;
+static inline void log_event(const value_iterator &iter, const char *type, std::string_view detail="", int delta=0, int depth_delta=0) noexcept;
+static inline void log_value(const value_iterator &iter, const char *type, std::string_view detail="", int delta=-1, int depth_delta=0) noexcept;
+static inline void log_start_value(const value_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
+static inline void log_end_value(const value_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
+static inline void log_error(const value_iterator &iter, const char *error, const char *detail="", int delta=-1, int depth_delta=0) noexcept;
 
 } // namespace logger
 } // namespace ondemand
@@ -18873,7 +20722,7 @@ public:
    * long strings.
    *
    * If target is a compile-time constant, and your compiler likes you,
-   * you should be able to do the following without performance penatly...
+   * you should be able to do the following without performance penalty...
    *
    *   static_assert(raw_json_string::is_free_from_unescaped_quote(target), "");
    *   s.unsafe_is_equal(target);
@@ -18887,7 +20736,7 @@ public:
    * the caller is responsible for this check. See is_free_from_unescaped_quote.
    *
    * If target is a compile-time constant, and your compiler likes you,
-   * you should be able to do the following without performance penatly...
+   * you should be able to do the following without performance penalty...
    *
    *   static_assert(raw_json_string::is_free_from_unescaped_quote(target), "");
    *   s.unsafe_is_equal(target);
@@ -19018,11 +20867,12 @@ public:
 
   /**
    * Advance to the next token (returning the current one).
-   *
-   * Does not check or update depth/expect_value. Caller is responsible for that.
    */
-  simdjson_really_inline const uint8_t *advance() noexcept;
-
+  simdjson_really_inline const uint8_t *return_current_and_advance() noexcept;
+  /**
+   * Reports the current offset in bytes from the start of the underlying buffer.
+   */
+  simdjson_really_inline uint32_t current_offset() const noexcept;
   /**
    * Get the JSON text for a given token (relative).
    *
@@ -19052,8 +20902,6 @@ public:
    *
    * @param position The position of the token.
    *
-   * TODO consider a string_view, assuming the length will get stripped out by the optimizer when
-   * it isn't used ...
    */
   simdjson_really_inline const uint8_t *peek(token_position position) const noexcept;
   /**
@@ -19066,13 +20914,13 @@ public:
   simdjson_really_inline uint32_t peek_length(token_position position) const noexcept;
 
   /**
-   * Save the current index to be restored later.
+   * Return the current index.
    */
   simdjson_really_inline token_position position() const noexcept;
   /**
    * Reset to a previously saved index.
    */
-  simdjson_really_inline void set_position(token_position target_checkpoint) noexcept;
+  simdjson_really_inline void set_position(token_position target_position) noexcept;
 
   // NOTE: we don't support a full C++ iterator interface, because we expect people to make
   // different calls to advance the iterator based on *their own* state.
@@ -19085,7 +20933,7 @@ public:
   simdjson_really_inline bool operator<=(const token_iterator &other) const noexcept;
 
 protected:
-  simdjson_really_inline token_iterator(const uint8_t *buf, token_position index) noexcept;
+  simdjson_really_inline token_iterator(const uint8_t *buf, token_position position) noexcept;
 
   /**
    * Get the index of the JSON text for a given token (relative).
@@ -19107,7 +20955,7 @@ protected:
   simdjson_really_inline uint32_t peek_index(token_position position) const noexcept;
 
   const uint8_t *buf{};
-  token_position index{};
+  token_position _position{};
 
   friend class json_iterator;
   friend class value_iterator;
@@ -19139,6 +20987,7 @@ namespace SIMDJSON_BUILTIN_IMPLEMENTATION {
 namespace ondemand {
 
 class document;
+class document_stream;
 class object;
 class array;
 class value;
@@ -19180,14 +21029,27 @@ protected:
    * - 3 = key or value inside root array/object.
    */
   depth_t _depth{};
+  /**
+   * Beginning of the document indexes.
+   * Normally we have root == parser->implementation->structural_indexes.get()
+   * but this may differ, especially in streaming mode (where we have several
+   * documents);
+   */
+  token_position _root{};
+  /**
+   * Normally, a json_iterator operates over a single document, but in
+   * some cases, we may have a stream of documents. This attribute is meant
+   * as meta-data: the json_iterator works the same irrespective of the
+   * value of this attribute.
+   */
+  bool _streaming{false};
 
 public:
   simdjson_really_inline json_iterator() noexcept = default;
   simdjson_really_inline json_iterator(json_iterator &&other) noexcept;
   simdjson_really_inline json_iterator &operator=(json_iterator &&other) noexcept;
-  simdjson_really_inline json_iterator(const json_iterator &other) noexcept = delete;
-  simdjson_really_inline json_iterator &operator=(const json_iterator &other) noexcept = delete;
-
+  simdjson_really_inline explicit json_iterator(const json_iterator &other) noexcept = default;
+  simdjson_really_inline json_iterator &operator=(const json_iterator &other) noexcept = default;
   /**
    * Skips a JSON value, whether it is a scalar, array or object.
    */
@@ -19199,9 +21061,17 @@ public:
   simdjson_really_inline bool at_root() const noexcept;
 
   /**
+   * Tell whether we should be expected to run in streaming
+   * mode (iterating over many documents). It is pure metadata
+   * that does not affect how the iterator works. It is used by
+   * start_root_array() and start_root_object().
+   */
+  simdjson_really_inline bool streaming() const noexcept;
+
+  /**
    * Get the root value iterator
    */
-  simdjson_really_inline token_position root_checkpoint() const noexcept;
+  simdjson_really_inline token_position root_position() const noexcept;
 
   /**
    * Assert if the iterator is not at the start
@@ -19211,7 +21081,7 @@ public:
   /**
    * Tell whether the iterator is at the EOF mark
    */
-  simdjson_really_inline bool at_eof() const noexcept;
+  simdjson_really_inline bool at_end() const noexcept;
 
   /**
    * Tell whether the iterator is live (has not been moved).
@@ -19224,10 +21094,22 @@ public:
   simdjson_really_inline void abandon() noexcept;
 
   /**
-   * Advance the current token.
+   * Advance the current token without modifying depth.
    */
-  simdjson_really_inline const uint8_t *advance() noexcept;
+  simdjson_really_inline const uint8_t *return_current_and_advance() noexcept;
 
+  /**
+   * Assert that there are at least the given number of tokens left.
+   *
+   * Has no effect in release builds.
+   */
+  simdjson_really_inline void assert_more_tokens(uint32_t required_tokens=1) const noexcept;
+  /**
+   * Assert that the given position addresses an actual token (is within bounds).
+   *
+   * Has no effect in release builds.
+   */
+  simdjson_really_inline void assert_valid_position(token_position position) const noexcept;
   /**
    * Get the JSON text for a given token (relative).
    *
@@ -19248,11 +21130,20 @@ public:
    */
   simdjson_really_inline uint32_t peek_length(int32_t delta=0) const noexcept;
   /**
+   * Get a pointer to the current location in the input buffer.
+   *
+   * This is not null-terminated; it is a view into the JSON.
+   *
+   * You may be pointing outside of the input buffer: it is not generally
+   * safe to derefence this pointer.
+   */
+  simdjson_really_inline const uint8_t *unsafe_pointer() const noexcept;
+  /**
    * Get the JSON text for a given token.
    *
    * This is not null-terminated; it is a view into the JSON.
    *
-   * @param index The position of the token to retrieve.
+   * @param position The position of the token to retrieve.
    *
    * TODO consider a string_view, assuming the length will get stripped out by the optimizer when
    * it isn't used ...
@@ -19263,7 +21154,7 @@ public:
    *
    * The length will include any whitespace at the end of the token.
    *
-   * @param index The position of the token to retrieve.
+   * @param position The position of the token to retrieve.
    */
   simdjson_really_inline uint32_t peek_length(token_position position) const noexcept;
   /**
@@ -19292,8 +21183,8 @@ public:
    *
    * @param child_depth the expected child depth.
    */
-  simdjson_really_inline void descend_to(depth_t parent_depth) noexcept;
-  simdjson_really_inline void descend_to(depth_t parent_depth, int32_t delta) noexcept;
+  simdjson_really_inline void descend_to(depth_t child_depth) noexcept;
+  simdjson_really_inline void descend_to(depth_t child_depth, int32_t delta) noexcept;
 
   /**
    * Get current depth.
@@ -19321,8 +21212,6 @@ public:
   simdjson_really_inline error_code optional_error(error_code error, const char *message) noexcept;
 
   template<int N> simdjson_warn_unused simdjson_really_inline bool copy_to_buffer(const uint8_t *json, uint32_t max_len, uint8_t (&tmpbuf)[N]) noexcept;
-  template<int N> simdjson_warn_unused simdjson_really_inline bool peek_to_buffer(uint8_t (&tmpbuf)[N]) noexcept;
-  template<int N> simdjson_warn_unused simdjson_really_inline bool advance_to_buffer(uint8_t (&tmpbuf)[N]) noexcept;
 
   simdjson_really_inline token_position position() const noexcept;
   simdjson_really_inline void reenter_child(token_position position, depth_t child_depth) noexcept;
@@ -19330,12 +21219,24 @@ public:
   simdjson_really_inline token_position start_position(depth_t depth) const noexcept;
   simdjson_really_inline void set_start_position(depth_t depth, token_position position) noexcept;
 #endif
-
+  /* Useful for debugging and logging purposes. */
+  inline std::string to_string() const noexcept;
+  /**
+   * Updates this json iterator so that it is back at the beginning of the document,
+   * as if it had just been created.
+   */
+  inline void rewind() noexcept;
 protected:
   simdjson_really_inline json_iterator(const uint8_t *buf, ondemand::parser *parser) noexcept;
-  simdjson_really_inline token_position last_document_position() const noexcept;
+  /// The last token before the end
+  simdjson_really_inline token_position last_position() const noexcept;
+  /// The token *at* the end. This points at gibberish and should only be used for comparison.
+  simdjson_really_inline token_position end_position() const noexcept;
+  /// The end of the buffer.
+  simdjson_really_inline token_position end() const noexcept;
 
   friend class document;
+  friend class document_stream;
   friend class object;
   friend class array;
   friend class value;
@@ -19391,8 +21292,6 @@ protected:
   depth_t _depth{};
   /**
    * The starting token index for this value
-   *
-   * PERF NOTE: this is a safety check; we expect this to be elided in release builds.
    */
   token_position _start_position{};
 
@@ -19414,7 +21313,7 @@ public:
   /**
    * Tell whether the iterator is at the EOF mark
    */
-  simdjson_really_inline bool at_eof() const noexcept;
+  simdjson_really_inline bool at_end() const noexcept;
 
   /**
    * Tell whether the iterator is at the start of the value
@@ -19451,7 +21350,7 @@ public:
    *
    * @error TAPE_ERROR when the JSON value is a bad token like "}" "," or "alse".
    */
-  simdjson_really_inline simdjson_result<json_type> type() noexcept;
+  simdjson_really_inline simdjson_result<json_type> type() const noexcept;
 
   /**
    * @addtogroup object Object iteration
@@ -19481,11 +21380,23 @@ public:
   /**
    * Start an object iteration after the user has already checked and moved past the {.
    *
-   * Does not move the iterator.
+   * Does not move the iterator unless the object is empty ({}).
    *
    * @returns Whether the object had any fields (returns false for empty).
+   * @error INCOMPLETE_ARRAY_OR_OBJECT If there are no more tokens (implying the *parent*
+   *        array or object is incomplete).
    */
-  simdjson_warn_unused simdjson_really_inline bool started_object() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> started_object() noexcept;
+  /**
+   * Start an object iteration from the root, after the user has already checked and moved past the {.
+   *
+   * Does not move the iterator unless the object is empty ({}).
+   *
+   * @returns Whether the object had any fields (returns false for empty).
+   * @error INCOMPLETE_ARRAY_OR_OBJECT If there are no more tokens (implying the *parent*
+   *        array or object is incomplete).
+   */
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> started_root_object() noexcept;
 
   /**
    * Moves to the next field in an object.
@@ -19495,6 +21406,7 @@ public:
    *
    * @return whether there is another field in the object.
    * @error TAPE_ERROR If there is a comma missing between fields.
+   * @error TAPE_ERROR If there is a comma, but not enough tokens remaining to have a key, :, and value.
    */
   simdjson_warn_unused simdjson_really_inline simdjson_result<bool> has_next_field() noexcept;
 
@@ -19591,13 +21503,25 @@ public:
   simdjson_warn_unused simdjson_really_inline simdjson_result<bool> start_root_array() noexcept;
 
   /**
-   * Start an array iteration after the user has already checked and moved past the [.
+   * Start an array iteration, after the user has already checked and moved past the [.
    *
-   * Does not move the iterator.
+   * Does not move the iterator unless the array is empty ([]).
    *
    * @returns Whether the array had any elements (returns false for empty).
+   * @error INCOMPLETE_ARRAY_OR_OBJECT If there are no more tokens (implying the *parent*
+   *        array or object is incomplete).
    */
-  simdjson_warn_unused simdjson_really_inline bool started_array() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> started_array() noexcept;
+  /**
+   * Start an array iteration from the root, after the user has already checked and moved past the [.
+   *
+   * Does not move the iterator unless the array is empty ([]).
+   *
+   * @returns Whether the array had any elements (returns false for empty).
+   * @error INCOMPLETE_ARRAY_OR_OBJECT If there are no more tokens (implying the *parent*
+   *        array or object is incomplete).
+   */
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> started_root_array() noexcept;
 
   /**
    * Moves to the next element in an array.
@@ -19626,16 +21550,22 @@ public:
   simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
   simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
   simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> get_uint64_in_string() noexcept;
   simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> get_int64_in_string() noexcept;
   simdjson_warn_unused simdjson_really_inline simdjson_result<double> get_double() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<double> get_double_in_string() noexcept;
   simdjson_warn_unused simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
   simdjson_really_inline bool is_null() noexcept;
 
   simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> get_root_string() noexcept;
   simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> get_root_raw_json_string() noexcept;
   simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> get_root_uint64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> get_root_uint64_in_string() noexcept;
   simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> get_root_int64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> get_root_int64_in_string() noexcept;
   simdjson_warn_unused simdjson_really_inline simdjson_result<double> get_root_double() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<double> get_root_double_in_string() noexcept;
   simdjson_warn_unused simdjson_really_inline simdjson_result<bool> get_root_bool() noexcept;
   simdjson_really_inline bool is_root_null() noexcept;
 
@@ -19648,31 +21578,130 @@ public:
   simdjson_really_inline bool is_valid() const noexcept;
 
   /** @} */
-
 protected:
+  /**
+   * Restarts an array iteration.
+   * @returns Whether the array has any elements (returns false for empty).
+   */
+  simdjson_really_inline simdjson_result<bool> reset_array() noexcept;
+  /**
+   * Restarts an object iteration.
+   * @returns Whether the object has any fields (returns false for empty).
+   */
+  simdjson_really_inline simdjson_result<bool> reset_object() noexcept;
+  /**
+   * move_at_start(): moves us so that we are pointing at the beginning of
+   * the container. It updates the index so that at_start() is true and it
+   * syncs the depth. The user can then create a new container instance.
+   *
+   * Usage: used with value::count_elements().
+   **/
+  simdjson_really_inline void move_at_start() noexcept;
+
+  /**
+   * move_at_container_start(): moves us so that we are pointing at the beginning of
+   * the container so that assert_at_container_start() passes.
+   *
+   * Usage: used with reset_array() and reset_object().
+   **/
+   simdjson_really_inline void move_at_container_start() noexcept;
+  /* Useful for debugging and logging purposes. */
+  inline std::string to_string() const noexcept;
   simdjson_really_inline value_iterator(json_iterator *json_iter, depth_t depth, token_position start_index) noexcept;
 
   simdjson_really_inline bool parse_null(const uint8_t *json) const noexcept;
   simdjson_really_inline simdjson_result<bool> parse_bool(const uint8_t *json) const noexcept;
-
   simdjson_really_inline const uint8_t *peek_start() const noexcept;
   simdjson_really_inline uint32_t peek_start_length() const noexcept;
-  simdjson_really_inline const uint8_t *advance_start(const char *type) const noexcept;
-  simdjson_really_inline error_code advance_container_start(const char *type, const uint8_t *&json) const noexcept;
-  simdjson_really_inline const uint8_t *advance_root_scalar(const char *type) const noexcept;
-  simdjson_really_inline const uint8_t *advance_non_root_scalar(const char *type) const noexcept;
+
+  /**
+   * The general idea of the advance_... methods and the peek_* methods
+   * is that you first peek and check that you have desired type. If you do,
+   * and only if you do, then you advance.
+   *
+   * We used to unconditionally advance. But this made reasoning about our
+   * current state difficult.
+   * Suppose you always advance. Look at the 'value' matching the key
+   * "shadowable" in the following example...
+   *
+   * ({"globals":{"a":{"shadowable":[}}}})
+   *
+   * If the user thinks it is a Boolean and asks for it, then we check the '[',
+   * decide it is not a Boolean, but still move into the next character ('}'). Now
+   * we are left pointing at '}' right after a '['. And we have not yet reported
+   * an error, only that we do not have a Boolean.
+   *
+   * If, instead, you just stand your ground until it is content that you know, then
+   * you will only even move beyond the '[' if the user tells you that you have an
+   * array. So you will be at the '}' character inside the array and, hopefully, you
+   * will then catch the error because an array cannot start with '}', but the code
+   * processing Boolean values does not know this.
+   *
+   * So the contract is: first call 'peek_...' and then call 'advance_...' only
+   * if you have determined that it is a type you can handle.
+   *
+   * Unfortunately, it makes the code more verbose, longer and maybe more error prone.
+   */
+
+  simdjson_really_inline void advance_scalar(const char *type) noexcept;
+  simdjson_really_inline void advance_root_scalar(const char *type) noexcept;
+  simdjson_really_inline void advance_non_root_scalar(const char *type) noexcept;
+
+  simdjson_really_inline const uint8_t *peek_scalar(const char *type) noexcept;
+  simdjson_really_inline const uint8_t *peek_root_scalar(const char *type) noexcept;
+  simdjson_really_inline const uint8_t *peek_non_root_scalar(const char *type) noexcept;
+
+
+  simdjson_really_inline error_code start_container(uint8_t start_char, const char *incorrect_type_message, const char *type) noexcept;
+  simdjson_really_inline error_code end_container() noexcept;
+
+  /**
+   * Advance to a place expecting a value (increasing depth).
+   *
+   * @return The current token (the one left behind).
+   * @error TAPE_ERROR If the document ended early.
+   */
+  simdjson_really_inline simdjson_result<const uint8_t *> advance_to_value() noexcept;
 
   simdjson_really_inline error_code incorrect_type_error(const char *message) const noexcept;
+  simdjson_really_inline error_code error_unless_more_tokens(uint32_t tokens=1) const noexcept;
 
   simdjson_really_inline bool is_at_start() const noexcept;
-  simdjson_really_inline bool is_at_container_start() const noexcept;
+  /**
+   * is_at_iterator_start() returns true on an array or object after it has just been
+   * created, whether the instance is empty or not.
+   *
+   * Usage: used by array::begin() in debug mode (SIMDJSON_DEVELOPMENT_CHECKS)
+   */
   simdjson_really_inline bool is_at_iterator_start() const noexcept;
-  simdjson_really_inline void assert_at_start() const noexcept;
-  simdjson_really_inline void assert_at_container_start() const noexcept;
-  simdjson_really_inline void assert_at_root() const noexcept;
-  simdjson_really_inline void assert_at_child() const noexcept;
-  simdjson_really_inline void assert_at_next() const noexcept;
-  simdjson_really_inline void assert_at_non_root_start() const noexcept;
+
+  /**
+   * Assuming that we are within an object, this returns true if we
+   * are pointing at a key.
+   *
+   * Usage: the skip_child() method should never be used while we are pointing
+   * at a key inside an object.
+   */
+  simdjson_really_inline bool is_at_key() const noexcept;
+
+  inline void assert_at_start() const noexcept;
+  inline void assert_at_container_start() const noexcept;
+  inline void assert_at_root() const noexcept;
+  inline void assert_at_child() const noexcept;
+  inline void assert_at_next() const noexcept;
+  inline void assert_at_non_root_start() const noexcept;
+
+  /** Get the starting position of this value */
+  simdjson_really_inline token_position start_position() const noexcept;
+
+  /** @copydoc error_code json_iterator::position() const noexcept; */
+  simdjson_really_inline token_position position() const noexcept;
+  /** @copydoc error_code json_iterator::end_position() const noexcept; */
+  simdjson_really_inline token_position last_position() const noexcept;
+  /** @copydoc error_code json_iterator::end_position() const noexcept; */
+  simdjson_really_inline token_position end_position() const noexcept;
+  /** @copydoc error_code json_iterator::report_error(error_code error, const char *message) noexcept; */
+  simdjson_really_inline error_code report_error(error_code error, const char *message) noexcept;
 
   friend class document;
   friend class object;
@@ -19894,8 +21923,60 @@ public:
    * Part of the std::iterable interface.
    */
   simdjson_really_inline simdjson_result<array_iterator> end() noexcept;
+  /**
+   * This method scans the array and counts the number of elements.
+   * The count_elements method should always be called before you have begun
+   * iterating through the array: it is expected that you are pointing at
+   * the beginning of the array.
+   * The runtime complexity is linear in the size of the array. After
+   * calling this function, if successful, the array is 'rewinded' at its
+   * beginning as if it had never been accessed. If the JSON is malformed (e.g.,
+   * there is a missing comma), then an error is returned and it is no longer
+   * safe to continue.
+   */
+  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+
+  /**
+   * Get the value associated with the given JSON pointer.  We use the RFC 6901
+   * https://tools.ietf.org/html/rfc6901 standard, interpreting the current node
+   * as the root of its own JSON document.
+   *
+   *   ondemand::parser parser;
+   *   auto json = R"([ { "foo": { "a": [ 10, 20, 30 ] }} ])"_padded;
+   *   auto doc = parser.iterate(json);
+   *   doc.at_pointer("/0/foo/a/1") == 20
+   *
+   * Note that at_pointer() called on the document automatically calls the document's rewind
+   * method between each call. It invalidates all previously accessed arrays, objects and values
+   * that have not been consumed. Yet it is not the case when calling at_pointer on an array
+   * instance: there is no rewind and no invalidation.
+   *
+   * You may only call at_pointer on an array after it has been created, but before it has
+   * been first accessed. When calling at_pointer on an array, the pointer is advanced to
+   * the location indicated by the JSON pointer (in case of success). It is no longer possible
+   * to call at_pointer on the same array.
+   *
+   * Also note that at_pointer() relies on find_field() which implies that we do not unescape keys when matching.
+   *
+   * @return The value associated with the given JSON pointer, or:
+   *         - NO_SUCH_FIELD if a field does not exist in an object
+   *         - INDEX_OUT_OF_BOUNDS if an array index is larger than an array length
+   *         - INCORRECT_TYPE if a non-integer is used to access an array
+   *         - INVALID_JSON_POINTER if the JSON pointer is invalid and cannot be parsed
+   */
+  inline simdjson_result<value> at_pointer(std::string_view json_pointer) noexcept;
+  /**
+   * Consumes the array and returns a string_view instance corresponding to the
+   * array as represented in JSON. It points inside the original document.
+   */
+  simdjson_really_inline simdjson_result<std::string_view> raw_json() noexcept;
 
 protected:
+  /**
+   * Go to the end of the array, no matter where you are right now.
+   */
+  simdjson_really_inline error_code consume() noexcept;
+
   /**
    * Begin array iteration.
    *
@@ -19921,7 +22002,7 @@ protected:
    *
    * @param iter The iterator. Must be after the initial [. Will be *moved* into the resulting array.
    */
-  static simdjson_really_inline array started(value_iterator &iter) noexcept;
+  static simdjson_really_inline simdjson_result<array> started(value_iterator &iter) noexcept;
 
   /**
    * Create an array at the given Internal array creation. Call array::start() or array::started() instead of this.
@@ -19931,6 +22012,15 @@ protected:
    *        into the resulting array.
    */
   simdjson_really_inline array(const value_iterator &iter) noexcept;
+
+  /**
+   * Get the value at the given index. This function has linear-time complexity.
+   * This function should only be called once as the array iterator is not reset between each call.
+   *
+   * @return The value at the given index, or:
+   *         - INDEX_OUT_OF_BOUNDS if the array index is larger than an array length
+   */
+  simdjson_really_inline simdjson_result<value> at(size_t index) noexcept;
 
   /**
    * Iterator marking current position.
@@ -19961,6 +22051,9 @@ public:
 
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array_iterator> begin() noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array_iterator> end() noexcept;
+  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> at(size_t index) noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
 };
 
 } // namespace simdjson
@@ -19977,9 +22070,10 @@ class object;
 class value;
 class raw_json_string;
 class array_iterator;
+class document_stream;
 
 /**
- * A JSON document iteration.
+ * A JSON document. It holds a json_iterator instance.
  *
  * Used by tokens to get text, and string buffer location.
  *
@@ -20020,6 +22114,13 @@ public:
    */
   simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
   /**
+   * Cast this JSON value (inside string) to an unsigned integer.
+   *
+   * @returns A signed 64-bit integer.
+   * @returns INCORRECT_TYPE If the JSON value is not a 64-bit unsigned integer.
+   */
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64_in_string() noexcept;
+  /**
    * Cast this JSON value to a signed integer.
    *
    * @returns A signed 64-bit integer.
@@ -20027,12 +22128,27 @@ public:
    */
   simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
   /**
+   * Cast this JSON value (inside string) to a signed integer.
+   *
+   * @returns A signed 64-bit integer.
+   * @returns INCORRECT_TYPE If the JSON value is not a 64-bit integer.
+   */
+  simdjson_really_inline simdjson_result<int64_t> get_int64_in_string() noexcept;
+  /**
    * Cast this JSON value to a double.
    *
    * @returns A double.
    * @returns INCORRECT_TYPE If the JSON value is not a valid floating-point number.
    */
   simdjson_really_inline simdjson_result<double> get_double() noexcept;
+
+  /**
+   * Cast this JSON value (inside string) to a double.
+   *
+   * @returns A double.
+   * @returns INCORRECT_TYPE If the JSON value is not a valid floating-point number.
+   */
+  simdjson_really_inline simdjson_result<double> get_double_in_string() noexcept;
   /**
    * Cast this JSON value to a string.
    *
@@ -20165,7 +22281,18 @@ public:
    */
   simdjson_really_inline operator bool() noexcept(false);
 #endif
-
+  /**
+   * This method scans the array and counts the number of elements.
+   * The count_elements method should always be called before you have begun
+   * iterating through the array: it is expected that you are pointing at
+   * the beginning of the array.
+   * The runtime complexity is linear in the size of the array. After
+   * calling this function, if successful, the array is 'rewinded' at its
+   * beginning as if it had never been accessed. If the JSON is malformed (e.g.,
+   * there is a missing comma), then an error is returned and it is no longer
+   * safe to continue.
+   */
+  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
   /**
    * Begin array iteration.
    *
@@ -20265,13 +22392,67 @@ public:
    */
   simdjson_really_inline simdjson_result<std::string_view> raw_json_token() noexcept;
 
+  /**
+   * Reset the iterator inside the document instance so we are pointing back at the
+   * beginning of the document, as if it had just been created. It invalidates all
+   * values, objects and arrays that you have created so far (including unescaped strings).
+   */
+  inline void rewind() noexcept;
+  /**
+   * Returns debugging information.
+   */
+  inline std::string to_debug_string() noexcept;
+
+  /**
+   * Get the value associated with the given JSON pointer.  We use the RFC 6901
+   * https://tools.ietf.org/html/rfc6901 standard.
+   *
+   *   ondemand::parser parser;
+   *   auto json = R"({ "foo": { "a": [ 10, 20, 30 ] }})"_padded;
+   *   auto doc = parser.iterate(json);
+   *   doc.at_pointer("/foo/a/1") == 20
+   *
+   * It is allowed for a key to be the empty string:
+   *
+   *   ondemand::parser parser;
+   *   auto json = R"({ "": { "a": [ 10, 20, 30 ] }})"_padded;
+   *   auto doc = parser.iterate(json);
+   *   doc.at_pointer("//a/1") == 20
+   *
+   * Note that at_pointer() automatically calls rewind between each call. Thus
+   * all values, objects and arrays that you have created so far (including unescaped strings)
+   * are invalidated. After calling at_pointer, you need to consume the result: string values
+   * should be stored in your own variables, arrays should be decoded and stored in your own array-like
+   * structures and so forth.
+   *
+   * Also note that at_pointer() relies on find_field() which implies that we do not unescape keys when matching
+   *
+   * @return The value associated with the given JSON pointer, or:
+   *         - NO_SUCH_FIELD if a field does not exist in an object
+   *         - INDEX_OUT_OF_BOUNDS if an array index is larger than an array length
+   *         - INCORRECT_TYPE if a non-integer is used to access an array
+   *         - INVALID_JSON_POINTER if the JSON pointer is invalid and cannot be parsed
+   */
+  simdjson_really_inline simdjson_result<value> at_pointer(std::string_view json_pointer) noexcept;
+  /**
+   * Consumes the document and returns a string_view instance corresponding to the
+   * document as represented in JSON. It points inside the original byte array containg
+   * the JSON document.
+   */
+  simdjson_really_inline simdjson_result<std::string_view> raw_json() noexcept;
 protected:
+  /**
+   * Consumes the document.
+   */
+  simdjson_really_inline error_code consume() noexcept;
+
   simdjson_really_inline document(ondemand::json_iterator &&iter) noexcept;
   simdjson_really_inline const uint8_t *text(uint32_t idx) const noexcept;
 
   simdjson_really_inline value_iterator resume_value_iterator() noexcept;
   simdjson_really_inline value_iterator get_root_value_iterator() noexcept;
-  simdjson_really_inline value resume_value() noexcept;
+  simdjson_really_inline simdjson_result<value> get_value_unsafe() noexcept;
+  simdjson_really_inline simdjson_result<object> start_or_resume_object() noexcept;
   static simdjson_really_inline document start(ondemand::json_iterator &&iter) noexcept;
 
   //
@@ -20280,7 +22461,6 @@ protected:
   json_iterator iter{}; ///< Current position in the document
   static constexpr depth_t DOCUMENT_DEPTH = 0; ///< document depth is always 0
 
-  friend struct simdjson_result<document>;
   friend class array_iterator;
   friend class value;
   friend class ondemand::parser;
@@ -20288,8 +22468,57 @@ protected:
   friend class array;
   friend class field;
   friend class token;
+  friend class document_stream;
 };
 
+
+/**
+ * A document_reference is a thin wrapper around a document reference instance.
+ */
+class document_reference {
+public:
+  simdjson_really_inline document_reference() noexcept;
+  simdjson_really_inline document_reference(document &d) noexcept;
+  simdjson_really_inline document_reference(const document_reference &other) noexcept = default;
+  simdjson_really_inline void rewind() noexcept;
+  simdjson_really_inline simdjson_result<array> get_array() & noexcept;
+  simdjson_really_inline simdjson_result<object> get_object() & noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_really_inline simdjson_result<double> get_double() noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
+  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_really_inline bool is_null() noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> raw_json() noexcept;
+  simdjson_really_inline operator document&() const noexcept;
+
+#if SIMDJSON_EXCEPTIONS
+  simdjson_really_inline operator array() & noexcept(false);
+  simdjson_really_inline operator object() & noexcept(false);
+  simdjson_really_inline operator uint64_t() noexcept(false);
+  simdjson_really_inline operator int64_t() noexcept(false);
+  simdjson_really_inline operator double() noexcept(false);
+  simdjson_really_inline operator std::string_view() noexcept(false);
+  simdjson_really_inline operator raw_json_string() noexcept(false);
+  simdjson_really_inline operator bool() noexcept(false);
+#endif
+  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_really_inline simdjson_result<array_iterator> begin() & noexcept;
+  simdjson_really_inline simdjson_result<array_iterator> end() & noexcept;
+  simdjson_really_inline simdjson_result<value> find_field(std::string_view key) & noexcept;
+  simdjson_really_inline simdjson_result<value> find_field(const char *key) & noexcept;
+  simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept;
+  simdjson_really_inline simdjson_result<value> operator[](const char *key) & noexcept;
+  simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept;
+  simdjson_really_inline simdjson_result<value> find_field_unordered(const char *key) & noexcept;
+
+  simdjson_really_inline simdjson_result<json_type> type() noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> raw_json_token() noexcept;
+  simdjson_really_inline simdjson_result<value> at_pointer(std::string_view json_pointer) noexcept;
+private:
+  document *doc{nullptr};
+};
 } // namespace ondemand
 } // namespace SIMDJSON_BUILTIN_IMPLEMENTATION
 } // namespace simdjson
@@ -20302,12 +22531,14 @@ public:
   simdjson_really_inline simdjson_result(SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document &&value) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
   simdjson_really_inline simdjson_result() noexcept = default;
+  simdjson_really_inline error_code rewind() noexcept;
 
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array> get_array() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object> get_object() & noexcept;
   simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
   simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
   simdjson_really_inline simdjson_result<double> get_double() noexcept;
+  simdjson_really_inline simdjson_result<double> get_double_from_string() noexcept;
   simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
   simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
@@ -20329,7 +22560,7 @@ public:
   simdjson_really_inline operator SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
   simdjson_really_inline operator bool() noexcept(false);
 #endif
-
+  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) & noexcept;
@@ -20343,7 +22574,62 @@ public:
 
   /** @copydoc simdjson_really_inline std::string_view document::raw_json_token() const noexcept */
   simdjson_really_inline simdjson_result<std::string_view> raw_json_token() noexcept;
+
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
 };
+
+
+} // namespace simdjson
+
+
+
+namespace simdjson {
+
+template<>
+struct simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference> : public SIMDJSON_BUILTIN_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference> {
+public:
+  simdjson_really_inline simdjson_result(SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference value, error_code error) noexcept;
+  simdjson_really_inline simdjson_result() noexcept = default;
+  simdjson_really_inline error_code rewind() noexcept;
+
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array> get_array() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object> get_object() & noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_really_inline simdjson_result<double> get_double() noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
+  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_really_inline bool is_null() noexcept;
+
+#if SIMDJSON_EXCEPTIONS
+  simdjson_really_inline operator SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array() & noexcept(false);
+  simdjson_really_inline operator SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object() & noexcept(false);
+  simdjson_really_inline operator uint64_t() noexcept(false);
+  simdjson_really_inline operator int64_t() noexcept(false);
+  simdjson_really_inline operator double() noexcept(false);
+  simdjson_really_inline operator std::string_view() noexcept(false);
+  simdjson_really_inline operator SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
+  simdjson_really_inline operator bool() noexcept(false);
+#endif
+  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> find_field(const char *key) & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> operator[](const char *key) & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> find_field_unordered(const char *key) & noexcept;
+
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::json_type> type() noexcept;
+
+  /** @copydoc simdjson_really_inline std::string_view document_reference::raw_json_token() const noexcept */
+  simdjson_really_inline simdjson_result<std::string_view> raw_json_token() noexcept;
+
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
+};
+
 
 } // namespace simdjson
 /* end file include/simdjson/generic/ondemand/document.h */
@@ -20418,10 +22704,18 @@ public:
   /**
    * Cast this JSON value to an unsigned integer.
    *
-   * @returns A signed 64-bit integer.
+   * @returns A unsigned 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit unsigned integer.
    */
   simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
+
+  /**
+   * Cast this JSON value (inside string) to a unsigned integer.
+   *
+   * @returns A unsigned 64-bit integer.
+   * @returns INCORRECT_TYPE If the JSON value is not a 64-bit unsigned integer.
+   */
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64_in_string() noexcept;
 
   /**
    * Cast this JSON value to a signed integer.
@@ -20432,12 +22726,28 @@ public:
   simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
 
   /**
+   * Cast this JSON value (inside string) to a signed integer.
+   *
+   * @returns A signed 64-bit integer.
+   * @returns INCORRECT_TYPE If the JSON value is not a 64-bit integer.
+   */
+  simdjson_really_inline simdjson_result<int64_t> get_int64_in_string() noexcept;
+
+  /**
    * Cast this JSON value to a double.
    *
    * @returns A double.
    * @returns INCORRECT_TYPE If the JSON value is not a valid floating-point number.
    */
   simdjson_really_inline simdjson_result<double> get_double() noexcept;
+
+  /**
+   * Cast this JSON value (inside string) to a double
+   *
+   * @returns A double.
+   * @returns INCORRECT_TYPE If the JSON value is not a valid floating-point number.
+   */
+  simdjson_really_inline simdjson_result<double> get_double_in_string() noexcept;
 
   /**
    * Cast this JSON value to a string.
@@ -20557,7 +22867,18 @@ public:
    * Part of the std::iterable interface.
    */
   simdjson_really_inline simdjson_result<array_iterator> end() & noexcept;
-
+  /**
+   * This method scans the array and counts the number of elements.
+   * The count_elements method should always be called before you have begun
+   * iterating through the array: it is expected that you are pointing at
+   * the beginning of the array.
+   * The runtime complexity is linear in the size of the array. After
+   * calling this function, if successful, the array is 'rewinded' at its
+   * beginning as if it had never been accessed. If the JSON is malformed (e.g.,
+   * there is a missing comma), then an error is returned and it is no longer
+   * safe to continue.
+   */
+  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
   /**
    * Look up a field by name on an object (order-sensitive).
    *
@@ -20652,6 +22973,50 @@ public:
    */
   simdjson_really_inline std::string_view raw_json_token() noexcept;
 
+  /**
+   * Get the value associated with the given JSON pointer.  We use the RFC 6901
+   * https://tools.ietf.org/html/rfc6901 standard.
+   *
+   *   ondemand::parser parser;
+   *   auto json = R"({ "foo": { "a": [ 10, 20, 30 ] }})"_padded;
+   *   auto doc = parser.iterate(json);
+   *   doc.at_pointer("/foo/a/1") == 20
+   *
+   * It is allowed for a key to be the empty string:
+   *
+   *   ondemand::parser parser;
+   *   auto json = R"({ "": { "a": [ 10, 20, 30 ] }})"_padded;
+   *   auto doc = parser.iterate(json);
+   *   doc.at_pointer("//a/1") == 20
+   *
+   * Note that at_pointer() called on the document automatically calls the document's rewind
+   * method between each call. It invalidates all previously accessed arrays, objects and values
+   * that have not been consumed.
+   *
+   * Calling at_pointer() on non-document instances (e.g., arrays and objects) is not
+   * standardized (by RFC 6901). We provide some experimental support for JSON pointers
+   * on non-document instances.  Yet it is not the case when calling at_pointer on an array
+   * or an object instance: there is no rewind and no invalidation.
+   *
+   * You may only call at_pointer on an array after it has been created, but before it has
+   * been first accessed. When calling at_pointer on an array, the pointer is advanced to
+   * the location indicated by the JSON pointer (in case of success). It is no longer possible
+   * to call at_pointer on the same array.
+   *
+   * You may call at_pointer more than once on an object, but each time the pointer is advanced
+   * to be within the value matched by the key indicated by the JSON pointer query. Thus any preceeding
+   * key (as well as the current key) can no longer be used with following JSON pointer calls.
+   *
+   * Also note that at_pointer() relies on find_field() which implies that we do not unescape keys when matching
+   *
+   * @return The value associated with the given JSON pointer, or:
+   *         - NO_SUCH_FIELD if a field does not exist in an object
+   *         - INDEX_OUT_OF_BOUNDS if an array index is larger than an array length
+   *         - INCORRECT_TYPE if a non-integer is used to access an array
+   *         - INVALID_JSON_POINTER if the JSON pointer is invalid and cannot be parsed
+   */
+  simdjson_really_inline simdjson_result<value> at_pointer(std::string_view json_pointer) noexcept;
+
 protected:
   /**
    * Create a value.
@@ -20690,7 +23055,6 @@ protected:
   friend class field;
   friend class object;
   friend struct simdjson_result<value>;
-  friend struct simdjson_result<document>;
   friend struct simdjson_result<field>;
 };
 
@@ -20711,8 +23075,11 @@ public:
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object> get_object() noexcept;
 
   simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64_in_string() noexcept;
   simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64_in_string() noexcept;
   simdjson_really_inline simdjson_result<double> get_double() noexcept;
+  simdjson_really_inline simdjson_result<double> get_double_in_string() noexcept;
   simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
   simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
@@ -20732,7 +23099,7 @@ public:
   simdjson_really_inline operator SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
   simdjson_really_inline operator bool() noexcept(false);
 #endif
-
+  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
 
@@ -20798,6 +23165,8 @@ public:
 
   /** @copydoc simdjson_really_inline std::string_view value::raw_json_token() const noexcept */
   simdjson_really_inline simdjson_result<std::string_view> raw_json_token() noexcept;
+
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
 };
 
 } // namespace simdjson
@@ -20895,7 +23264,6 @@ public:
 
   simdjson_really_inline simdjson_result<object_iterator> begin() noexcept;
   simdjson_really_inline simdjson_result<object_iterator> end() noexcept;
-
   /**
    * Look up a field by name on an object (order-sensitive).
    *
@@ -20952,10 +23320,57 @@ public:
   /** @overload simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept; */
   simdjson_really_inline simdjson_result<value> operator[](std::string_view key) && noexcept;
 
+  /**
+   * Get the value associated with the given JSON pointer. We use the RFC 6901
+   * https://tools.ietf.org/html/rfc6901 standard, interpreting the current node
+   * as the root of its own JSON document.
+   *
+   *   ondemand::parser parser;
+   *   auto json = R"({ "foo": { "a": [ 10, 20, 30 ] }})"_padded;
+   *   auto doc = parser.iterate(json);
+   *   doc.at_pointer("/foo/a/1") == 20
+   *
+   * It is allowed for a key to be the empty string:
+   *
+   *   ondemand::parser parser;
+   *   auto json = R"({ "": { "a": [ 10, 20, 30 ] }})"_padded;
+   *   auto doc = parser.iterate(json);
+   *   doc.at_pointer("//a/1") == 20
+   *
+   * Note that at_pointer() called on the document automatically calls the document's rewind
+   * method between each call. It invalidates all previously accessed arrays, objects and values
+   * that have not been consumed. Yet it is not the case when calling at_pointer on an object
+   * instance: there is no rewind and no invalidation.
+   *
+   * You may call at_pointer more than once on an object, but each time the pointer is advanced
+   * to be within the value matched by the key indicated by the JSON pointer query. Thus any preceeding
+   * key (as well as the current key) can no longer be used with following JSON pointer calls.
+   *
+   * Also note that at_pointer() relies on find_field() which implies that we do not unescape keys when matching.
+   *
+   * @return The value associated with the given JSON pointer, or:
+   *         - NO_SUCH_FIELD if a field does not exist in an object
+   *         - INDEX_OUT_OF_BOUNDS if an array index is larger than an array length
+   *         - INCORRECT_TYPE if a non-integer is used to access an array
+   *         - INVALID_JSON_POINTER if the JSON pointer is invalid and cannot be parsed
+   */
+  inline simdjson_result<value> at_pointer(std::string_view json_pointer) noexcept;
+
+  /**
+   * Consumes the object and returns a string_view instance corresponding to the
+   * object as represented in JSON. It points inside the original byte array containg
+   * the JSON document.
+   */
+  simdjson_really_inline simdjson_result<std::string_view> raw_json() noexcept;
+
 protected:
+  /**
+   * Go to the end of the object, no matter where you are right now.
+   */
+  simdjson_really_inline error_code consume() noexcept;
   static simdjson_really_inline simdjson_result<object> start(value_iterator &iter) noexcept;
   static simdjson_really_inline simdjson_result<object> start_root(value_iterator &iter) noexcept;
-  static simdjson_really_inline object started(value_iterator &iter) noexcept;
+  static simdjson_really_inline simdjson_result<object> started(value_iterator &iter) noexcept;
   static simdjson_really_inline object resume(const value_iterator &iter) noexcept;
   simdjson_really_inline object(const value_iterator &iter) noexcept;
 
@@ -20989,6 +23404,7 @@ public:
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) && noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) && noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
 };
 
 } // namespace simdjson
@@ -21003,6 +23419,23 @@ class array;
 class object;
 class value;
 class raw_json_string;
+class document_stream;
+
+/**
+ * The default batch size for document_stream instances for this On Demand kernel.
+ * Note that different On Demand kernel may use a different DEFAULT_BATCH_SIZE value
+ * in the future.
+ */
+static constexpr size_t DEFAULT_BATCH_SIZE = 1000000;
+/**
+ * Some adversary might try to set the batch size to 0 or 1, which might cause problems.
+ * We set a minimum of 32B since anything else is highly likely to be an error. In practice,
+ * most users will want a much larger batch size.
+ *
+ * All non-negative MINIMAL_BATCH_SIZE values should be 'safe' except that, obviously, no JSON
+ * document can ever span 0 or 1 byte and that very large values would create memory allocation issues.
+ */
+static constexpr size_t MINIMAL_BATCH_SIZE = 32;
 
 /**
  * A JSON fragment iterator.
@@ -21016,11 +23449,12 @@ public:
    *
    * The new parser will have zero capacity.
    */
-  inline parser() noexcept = default;
+  inline explicit parser(size_t max_capacity = SIMDJSON_MAXSIZE_BYTES) noexcept;
 
   inline parser(parser &&other) noexcept = default;
   simdjson_really_inline parser(const parser &other) = delete;
   simdjson_really_inline parser &operator=(const parser &other) = delete;
+  simdjson_really_inline parser &operator=(parser &&other) noexcept = default;
 
   /** Deallocate the JSON parser. */
   inline ~parser() noexcept = default;
@@ -21030,6 +23464,11 @@ public:
    *
    *   ondemand::parser parser;
    *   document doc = parser.iterate(json);
+   *
+   * ### IMPORTANT: Validate what you use
+   *
+   * Calling iterate on an invalid JSON document may not immediately trigger an error. The call to
+   * iterate does not parse and validate the whole document.
    *
    * ### IMPORTANT: Buffer Lifetime
    *
@@ -21101,8 +23540,6 @@ public:
    * those bytes are initialized to, as long as they are allocated.
    *
    * @param json The JSON to parse.
-   * @param len The length of the JSON.
-   * @param allocated The number of bytes allocated in the JSON (must be at least len+SIMDJSON_PADDING).
    *
    * @return The iterator, or an error:
    *         - INSUFFICIENT_PADDING if the input has less than SIMDJSON_PADDING extra bytes.
@@ -21115,20 +23552,87 @@ public:
    */
   simdjson_warn_unused simdjson_result<json_iterator> iterate_raw(padded_string_view json) & noexcept;
 
+
+  /**
+   * Parse a buffer containing many JSON documents.
+   *
+   *   auto json = R"({ "foo": 1 } { "foo": 2 } { "foo": 3 } )"_padded;
+   *   ondemand::parser parser;
+   *   ondemand::document_stream docs = parser.iterate_many(json);
+   *   for (auto & doc : docs) {
+   *     std::cout << doc["foo"] << std::endl;
+   *   }
+   *   // Prints 1 2 3
+   *
+   * No copy of the input buffer is made.
+   *
+   * The function is lazy: it may be that no more than one JSON document at a time is parsed.
+   *
+   * The caller is responsabile to ensure that the input string data remains unchanged and is
+   * not deleted during the loop.
+   *
+   * ### Format
+   *
+   * The buffer must contain a series of one or more JSON documents, concatenated into a single
+   * buffer, separated by whitespace. It effectively parses until it has a fully valid document,
+   * then starts parsing the next document at that point. (It does this with more parallelism and
+   * lookahead than you might think, though.)
+   *
+   * documents that consist of an object or array may omit the whitespace between them, concatenating
+   * with no separator. documents that consist of a single primitive (i.e. documents that are not
+   * arrays or objects) MUST be separated with whitespace.
+   *
+   * The documents must not exceed batch_size bytes (by default 1MB) or they will fail to parse.
+   * Setting batch_size to excessively large or excesively small values may impact negatively the
+   * performance.
+   *
+   * ### REQUIRED: Buffer Padding
+   *
+   * The buffer must have at least SIMDJSON_PADDING extra allocated bytes. It does not matter what
+   * those bytes are initialized to, as long as they are allocated.
+   *
+   * ### Threads
+   *
+   * When compiled with SIMDJSON_THREADS_ENABLED, this method will use a single thread under the
+   * hood to do some lookahead.
+   *
+   * ### Parser Capacity
+   *
+   * If the parser's current capacity is less than batch_size, it will allocate enough capacity
+   * to handle it (up to max_capacity).
+   *
+   * @param buf The concatenated JSON to parse.
+   * @param len The length of the concatenated JSON.
+   * @param batch_size The batch size to use. MUST be larger than the largest document. The sweet
+   *                   spot is cache-related: small enough to fit in cache, yet big enough to
+   *                   parse as many documents as possible in one tight loop.
+   *                   Defaults to 10MB, which has been a reasonable sweet spot in our tests.
+   * @return The stream, or an error. An empty input will yield 0 documents rather than an EMPTY error. Errors:
+   *         - MEMALLOC if the parser does not have enough capacity and memory allocation fails
+   *         - CAPACITY if the parser does not have enough capacity and batch_size > max_capacity.
+   *         - other json errors if parsing fails. You should not rely on these errors to always the same for the
+   *           same document: they may vary under runtime dispatch (so they may vary depending on your system and hardware).
+   */
+  inline simdjson_result<document_stream> iterate_many(const uint8_t *buf, size_t len, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  /** @overload parse_many(const uint8_t *buf, size_t len, size_t batch_size) */
+  inline simdjson_result<document_stream> iterate_many(const char *buf, size_t len, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  /** @overload parse_many(const uint8_t *buf, size_t len, size_t batch_size) */
+  inline simdjson_result<document_stream> iterate_many(const std::string &s, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> iterate_many(const std::string &&s, size_t batch_size) = delete;// unsafe
+  /** @overload parse_many(const uint8_t *buf, size_t len, size_t batch_size) */
+  inline simdjson_result<document_stream> iterate_many(const padded_string &s, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> iterate_many(const padded_string &&s, size_t batch_size) = delete;// unsafe
+
+  /** @private We do not want to allow implicit conversion from C string to std::string. */
+  simdjson_result<document_stream> iterate_many(const char *buf, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept = delete;
+
   /** The capacity of this parser (the largest document it can process). */
   simdjson_really_inline size_t capacity() const noexcept;
+  /** The maximum capacity of this parser (the largest document it is allowed to process). */
+  simdjson_really_inline size_t max_capacity() const noexcept;
+  simdjson_really_inline void set_max_capacity(size_t max_capacity) noexcept;
   /** The maximum depth of this parser (the most deeply nested objects and arrays it can process). */
   simdjson_really_inline size_t max_depth() const noexcept;
-
-private:
-  /** @private [for benchmarking access] The implementation to use */
-  std::unique_ptr<internal::dom_parser_implementation> implementation{};
-  size_t _capacity{0};
-  size_t _max_depth{DEFAULT_MAX_DEPTH};
-  std::unique_ptr<uint8_t[]> string_buf{};
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
-  std::unique_ptr<token_position[]> start_positions{};
-#endif
 
   /**
    * Ensure this parser has enough memory to process JSON documents up to `capacity` bytes in length
@@ -21140,7 +23644,28 @@ private:
    */
   simdjson_warn_unused error_code allocate(size_t capacity, size_t max_depth=DEFAULT_MAX_DEPTH) noexcept;
 
+  #ifdef SIMDJSON_THREADS_ENABLED
+  /**
+   * The parser instance can use threads when they are available to speed up some
+   * operations. It is enabled by default. Changing this attribute will change the
+   * behavior of the parser for future operations.
+   */
+  bool threaded{true};
+  #endif
+
+private:
+  /** @private [for benchmarking access] The implementation to use */
+  std::unique_ptr<internal::dom_parser_implementation> implementation{};
+  size_t _capacity{0};
+  size_t _max_capacity;
+  size_t _max_depth{DEFAULT_MAX_DEPTH};
+  std::unique_ptr<uint8_t[]> string_buf{};
+#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+  std::unique_ptr<token_position[]> start_positions{};
+#endif
+
   friend class json_iterator;
+  friend class document_stream;
 };
 
 } // namespace ondemand
@@ -21159,6 +23684,417 @@ public:
 
 } // namespace simdjson
 /* end file include/simdjson/generic/ondemand/parser.h */
+/* begin file include/simdjson/generic/ondemand/document_stream.h */
+#ifdef SIMDJSON_THREADS_ENABLED
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#endif
+
+namespace simdjson {
+namespace SIMDJSON_BUILTIN_IMPLEMENTATION {
+namespace ondemand {
+
+class parser;
+class json_iterator;
+class document;
+
+#ifdef SIMDJSON_THREADS_ENABLED
+/** @private Custom worker class **/
+struct stage1_worker {
+  stage1_worker() noexcept = default;
+  stage1_worker(const stage1_worker&) = delete;
+  stage1_worker(stage1_worker&&) = delete;
+  stage1_worker operator=(const stage1_worker&) = delete;
+  ~stage1_worker();
+  /**
+   * We only start the thread when it is needed, not at object construction, this may throw.
+   * You should only call this once.
+   **/
+  void start_thread();
+  /**
+   * Start a stage 1 job. You should first call 'run', then 'finish'.
+   * You must call start_thread once before.
+   */
+  void run(document_stream * ds, parser * stage1, size_t next_batch_start);
+  /** Wait for the run to finish (blocking). You should first call 'run', then 'finish'. **/
+  void finish();
+
+private:
+
+  /**
+   * Normally, we would never stop the thread. But we do in the destructor.
+   * This function is only safe assuming that you are not waiting for results. You
+   * should have called run, then finish, and be done.
+   **/
+  void stop_thread();
+
+  std::thread thread{};
+  /** These three variables define the work done by the thread. **/
+  ondemand::parser * stage1_thread_parser{};
+  size_t _next_batch_start{};
+  document_stream * owner{};
+  /**
+   * We have two state variables. This could be streamlined to one variable in the future but
+   * we use two for clarity.
+   */
+  bool has_work{false};
+  bool can_work{true};
+
+  /**
+   * We lock using a mutex.
+   */
+  std::mutex locking_mutex{};
+  std::condition_variable cond_var{};
+
+  friend class document_stream;
+};
+#endif  // SIMDJSON_THREADS_ENABLED
+
+/**
+ * A forward-only stream of documents.
+ *
+ * Produced by parser::iterate_many.
+ *
+ */
+class document_stream {
+public:
+  /**
+   * Construct an uninitialized document_stream.
+   *
+   *  ```c++
+   *  document_stream docs;
+   *  auto error = parser.iterate_many(json).get(docs);
+   *  ```
+   */
+  simdjson_really_inline document_stream() noexcept;
+  /** Move one document_stream to another. */
+  simdjson_really_inline document_stream(document_stream &&other) noexcept = default;
+  /** Move one document_stream to another. */
+  simdjson_really_inline document_stream &operator=(document_stream &&other) noexcept = default;
+
+  simdjson_really_inline ~document_stream() noexcept;
+
+  /**
+   * Returns the input size in bytes.
+   */
+  inline size_t size_in_bytes() const noexcept;
+
+  /**
+   * After iterating through the stream, this method
+   * returns the number of bytes that were not parsed at the end
+   * of the stream. If truncated_bytes() differs from zero,
+   * then the input was truncated maybe because incomplete JSON
+   * documents were found at the end of the stream. You
+   * may need to process the bytes in the interval [size_in_bytes()-truncated_bytes(), size_in_bytes()).
+   *
+   * You should only call truncated_bytes() after streaming through all
+   * documents, like so:
+   *
+   *   document_stream stream = parser.iterate_many(json,window);
+   *   for(auto & doc : stream) {
+   *      // do something with doc
+   *   }
+   *   size_t truncated = stream.truncated_bytes();
+   *
+   */
+  inline size_t truncated_bytes() const noexcept;
+
+  class iterator {
+  public:
+    using value_type = simdjson_result<document>;
+    using reference  = value_type;
+
+    using difference_type   = std::ptrdiff_t;
+
+    using iterator_category = std::input_iterator_tag;
+
+    /**
+     * Default constructor.
+     */
+    simdjson_really_inline iterator() noexcept;
+    /**
+     * Get the current document (or error).
+     */
+    simdjson_really_inline simdjson_result<ondemand::document_reference> operator*() noexcept;
+    /**
+     * Advance to the next document (prefix).
+     */
+    inline iterator& operator++() noexcept;
+    /**
+     * Check if we're at the end yet.
+     * @param other the end iterator to compare to.
+     */
+    simdjson_really_inline bool operator!=(const iterator &other) const noexcept;
+    /**
+     * @private
+     *
+     * Gives the current index in the input document in bytes.
+     *
+     *   document_stream stream = parser.parse_many(json,window);
+     *   for(auto i = stream.begin(); i != stream.end(); ++i) {
+     *      auto doc = *i;
+     *      size_t index = i.current_index();
+     *   }
+     *
+     * This function (current_index()) is experimental and the usage
+     * may change in future versions of simdjson: we find the API somewhat
+     * awkward and we would like to offer something friendlier.
+     */
+     simdjson_really_inline size_t current_index() const noexcept;
+
+     /**
+     * @private
+     *
+     * Gives a view of the current document at the current position.
+     *
+     *   document_stream stream = parser.iterate_many(json,window);
+     *   for(auto i = stream.begin(); i != stream.end(); ++i) {
+     *      std::string_view v = i.source();
+     *   }
+     *
+     * The returned string_view instance is simply a map to the (unparsed)
+     * source string: it may thus include white-space characters and all manner
+     * of padding.
+     *
+     * This function (source()) is experimental and the usage
+     * may change in future versions of simdjson: we find the API somewhat
+     * awkward and we would like to offer something friendlier.
+     *
+     */
+     simdjson_really_inline std::string_view source() const noexcept;
+
+    /**
+     * Returns error of the stream (if any).
+     */
+     inline error_code error() const noexcept;
+
+  private:
+    simdjson_really_inline iterator(document_stream *s, bool finished) noexcept;
+    /** The document_stream we're iterating through. */
+    document_stream* stream;
+    /** Whether we're finished or not. */
+    bool finished;
+
+    friend class document;
+    friend class document_stream;
+    friend class json_iterator;
+  };
+
+  /**
+   * Start iterating the documents in the stream.
+   */
+  simdjson_really_inline iterator begin() noexcept;
+  /**
+   * The end of the stream, for iterator comparison purposes.
+   */
+  simdjson_really_inline iterator end() noexcept;
+
+private:
+
+  document_stream &operator=(const document_stream &) = delete; // Disallow copying
+  document_stream(const document_stream &other) = delete; // Disallow copying
+
+  /**
+   * Construct a document_stream. Does not allocate or parse anything until the iterator is
+   * used.
+   *
+   * @param parser is a reference to the parser instance used to generate this document_stream
+   * @param buf is the raw byte buffer we need to process
+   * @param len is the length of the raw byte buffer in bytes
+   * @param batch_size is the size of the windows (must be strictly greater or equal to the largest JSON document)
+   */
+  simdjson_really_inline document_stream(
+    ondemand::parser &parser,
+    const uint8_t *buf,
+    size_t len,
+    size_t batch_size
+  ) noexcept;
+
+  /**
+   * Parse the first document in the buffer. Used by begin(), to handle allocation and
+   * initialization.
+   */
+  inline void start() noexcept;
+
+  /**
+   * Parse the next document found in the buffer previously given to document_stream.
+   *
+   * The content should be a valid JSON document encoded as UTF-8. If there is a
+   * UTF-8 BOM, the caller is responsible for omitting it, UTF-8 BOM are
+   * discouraged.
+   *
+   * You do NOT need to pre-allocate a parser.  This function takes care of
+   * pre-allocating a capacity defined by the batch_size defined when creating the
+   * document_stream object.
+   *
+   * The function returns simdjson::EMPTY if there is no more data to be parsed.
+   *
+   * The function returns simdjson::SUCCESS (as integer = 0) in case of success
+   * and indicates that the buffer has successfully been parsed to the end.
+   * Every document it contained has been parsed without error.
+   *
+   * The function returns an error code from simdjson/simdjson.h in case of failure
+   * such as simdjson::CAPACITY, simdjson::MEMALLOC, simdjson::DEPTH_ERROR and so forth;
+   * the simdjson::error_message function converts these error codes into a string).
+   *
+   * You can also check validity by calling parser.is_valid(). The same parser can
+   * and should be reused for the other documents in the buffer.
+   */
+  inline void next() noexcept;
+
+  /** Move the json_iterator of the document to the location of the next document in the stream. */
+  inline void next_document() noexcept;
+
+  /** Get the next document index. */
+  inline size_t next_batch_start() const noexcept;
+
+  /** Pass the next batch through stage 1 with the given parser. */
+  inline error_code run_stage1(ondemand::parser &p, size_t batch_start) noexcept;
+
+  // Fields
+  ondemand::parser *parser;
+  const uint8_t *buf;
+  size_t len;
+  size_t batch_size;
+  /**
+   * We are going to use just one document instance. The document owns
+   * the json_iterator. It implies that we only ever pass a reference
+   * to the document to the users.
+   */
+  document doc{};
+  /** The error (or lack thereof) from the current document. */
+  error_code error;
+  size_t batch_start{0};
+  size_t doc_index{};
+
+  #ifdef SIMDJSON_THREADS_ENABLED
+  /** Indicates whether we use threads. Note that this needs to be a constant during the execution of the parsing. */
+  bool use_thread;
+
+  inline void load_from_stage1_thread() noexcept;
+
+  /** Start a thread to run stage 1 on the next batch. */
+  inline void start_stage1_thread() noexcept;
+
+  /** Wait for the stage 1 thread to finish and capture the results. */
+  inline void finish_stage1_thread() noexcept;
+
+  /** The error returned from the stage 1 thread. */
+  error_code stage1_thread_error{UNINITIALIZED};
+  /** The thread used to run stage 1 against the next batch in the background. */
+  std::unique_ptr<stage1_worker> worker{new(std::nothrow) stage1_worker()};
+  /**
+   * The parser used to run stage 1 in the background. Will be swapped
+   * with the regular parser when finished.
+   */
+  ondemand::parser stage1_thread_parser{};
+
+  friend struct stage1_worker;
+  #endif // SIMDJSON_THREADS_ENABLED
+
+  friend class parser;
+  friend class document;
+  friend class json_iterator;
+  friend struct simdjson_result<ondemand::document_stream>;
+  friend struct internal::simdjson_result_base<ondemand::document_stream>;
+};  // document_stream
+
+} // namespace ondemand
+} // namespace SIMDJSON_BUILTIN_IMPLEMENTATION
+} // namespace simdjson
+
+namespace simdjson {
+template<>
+struct simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_stream> : public SIMDJSON_BUILTIN_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_stream> {
+public:
+  simdjson_really_inline simdjson_result(SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_stream &&value) noexcept; ///< @private
+  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_really_inline simdjson_result() noexcept = default;
+};
+
+} // namespace simdjson
+/* end file include/simdjson/generic/ondemand/document_stream.h */
+/* begin file include/simdjson/generic/ondemand/serialization.h */
+
+namespace simdjson {
+/**
+ * Create a string-view instance out of a document instance. The string-view instance
+ * contains JSON text that is suitable to be parsed as JSON again.
+ */
+inline simdjson_result<std::string_view> to_json_string(SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document& x) noexcept;
+/**
+ * Create a string-view instance out of a value instance. The string-view instance
+ * contains JSON text that is suitable to be parsed as JSON again. The value must
+ * not have been accessed previously.
+ */
+inline simdjson_result<std::string_view> to_json_string(SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value& x) noexcept;
+/**
+ * Create a string-view instance out of an object instance. The string-view instance
+ * contains JSON text that is suitable to be parsed as JSON again.
+ */
+inline simdjson_result<std::string_view> to_json_string(SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object& x) noexcept;
+/**
+ * Create a string-view instance out of an array instance. The string-view instance
+ * contains JSON text that is suitable to be parsed as JSON again.
+ */
+inline simdjson_result<std::string_view> to_json_string(SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array& x) noexcept;
+inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document> x);
+inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> x);
+inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object> x);
+inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array> x);
+} // namespace simdjson
+
+
+/**
+ * Print JSON to an output stream.
+ *
+ * @param out The output stream.
+ * @param value The element.
+ * @throw if there is an error with the underlying output stream. simdjson itself will not throw.
+ */
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value x);
+#if SIMDJSON_EXCEPTIONS
+inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> x);
+#endif
+/**
+ * Print JSON to an output stream.
+ *
+ * @param out The output stream.
+ * @param value The array.
+ * @throw if there is an error with the underlying output stream. simdjson itself will not throw.
+ */
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array value);
+#if SIMDJSON_EXCEPTIONS
+inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array> x);
+#endif
+/**
+ * Print JSON to an output stream.
+ *
+ * @param out The output stream.
+ * @param value The array.
+ * @throw if there is an error with the underlying output stream. simdjson itself will not throw.
+ */
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document& value);
+#if SIMDJSON_EXCEPTIONS
+inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document>&& x);
+#endif
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference& value);
+#if SIMDJSON_EXCEPTIONS
+inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>&& x);
+#endif
+/**
+ * Print JSON to an output stream.
+ *
+ * @param out The output stream.
+ * @param value The object.
+ * @throw if there is an error with the underlying output stream. simdjson itself will not throw.
+ */
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object value);
+#if SIMDJSON_EXCEPTIONS
+inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object> x);
+#endif
+/* end file include/simdjson/generic/ondemand/serialization.h */
 /* end file include/simdjson/generic/ondemand.h */
 
 // Inline definitions
@@ -21214,8 +24150,15 @@ simdjson_really_inline implementation_simdjson_result_base<T>::operator T&&() &&
   return std::forward<implementation_simdjson_result_base<T>>(*this).take_value();
 }
 
+#endif // SIMDJSON_EXCEPTIONS
+
 template<typename T>
 simdjson_really_inline const T& implementation_simdjson_result_base<T>::value_unsafe() const& noexcept {
+  return this->first;
+}
+
+template<typename T>
+simdjson_really_inline T& implementation_simdjson_result_base<T>::value_unsafe() & noexcept {
   return this->first;
 }
 
@@ -21223,8 +24166,6 @@ template<typename T>
 simdjson_really_inline T&& implementation_simdjson_result_base<T>::value_unsafe() && noexcept {
   return std::forward<T>(this->first);
 }
-
-#endif // SIMDJSON_EXCEPTIONS
 
 template<typename T>
 simdjson_really_inline implementation_simdjson_result_base<T>::implementation_simdjson_result_base(T &&value, error_code error) noexcept
@@ -21290,7 +24231,7 @@ static constexpr const int LOG_SMALL_BUFFER_LEN = 10;
 static int log_depth = 0; // Not threadsafe. Log only.
 
 // Helper to turn unprintable or newline characters into spaces
-static simdjson_really_inline char printable_char(char c) {
+static inline char printable_char(char c) {
   if (c >= 0x20) {
     return c;
   } else {
@@ -21298,61 +24239,89 @@ static simdjson_really_inline char printable_char(char c) {
   }
 }
 
-simdjson_really_inline void log_event(const json_iterator &iter, const char *type, std::string_view detail, int delta, int depth_delta) noexcept {
+inline void log_event(const json_iterator &iter, const char *type, std::string_view detail, int delta, int depth_delta) noexcept {
   log_line(iter, "", type, detail, delta, depth_delta);
 }
 
-simdjson_really_inline void log_value(const json_iterator &iter, token_position index, depth_t depth, const char *type, std::string_view detail) noexcept {
+inline void log_value(const json_iterator &iter, token_position index, depth_t depth, const char *type, std::string_view detail) noexcept {
   log_line(iter, index, depth, "", type, detail);
 }
-simdjson_really_inline void log_value(const json_iterator &iter, const char *type, std::string_view detail, int delta, int depth_delta) noexcept {
+inline void log_value(const json_iterator &iter, const char *type, std::string_view detail, int delta, int depth_delta) noexcept {
   log_line(iter, "", type, detail, delta, depth_delta);
 }
 
-simdjson_really_inline void log_start_value(const json_iterator &iter, token_position index, depth_t depth, const char *type, std::string_view detail) noexcept {
+inline void log_start_value(const json_iterator &iter, token_position index, depth_t depth, const char *type, std::string_view detail) noexcept {
   log_line(iter, index, depth, "+", type, detail);
   if (LOG_ENABLED) { log_depth++; }
 }
-simdjson_really_inline void log_start_value(const json_iterator &iter, const char *type, int delta, int depth_delta) noexcept {
+inline void log_start_value(const json_iterator &iter, const char *type, int delta, int depth_delta) noexcept {
   log_line(iter, "+", type, "", delta, depth_delta);
   if (LOG_ENABLED) { log_depth++; }
 }
 
-simdjson_really_inline void log_end_value(const json_iterator &iter, const char *type, int delta, int depth_delta) noexcept {
+inline void log_end_value(const json_iterator &iter, const char *type, int delta, int depth_delta) noexcept {
   if (LOG_ENABLED) { log_depth--; }
   log_line(iter, "-", type, "", delta, depth_delta);
 }
 
-simdjson_really_inline void log_error(const json_iterator &iter, const char *error, const char *detail, int delta, int depth_delta) noexcept {
+inline void log_error(const json_iterator &iter, const char *error, const char *detail, int delta, int depth_delta) noexcept {
   log_line(iter, "ERROR: ", error, detail, delta, depth_delta);
 }
-simdjson_really_inline void log_error(const json_iterator &iter, token_position index, depth_t depth, const char *error, const char *detail) noexcept {
+inline void log_error(const json_iterator &iter, token_position index, depth_t depth, const char *error, const char *detail) noexcept {
   log_line(iter, index, depth, "ERROR: ", error, detail);
 }
 
-simdjson_really_inline void log_event(const value_iterator &iter, const char *type, std::string_view detail, int delta, int depth_delta) noexcept {
+inline void log_event(const value_iterator &iter, const char *type, std::string_view detail, int delta, int depth_delta) noexcept {
   log_event(iter.json_iter(), type, detail, delta, depth_delta);
 }
 
-simdjson_really_inline void log_value(const value_iterator &iter, const char *type, std::string_view detail, int delta, int depth_delta) noexcept {
+inline void log_value(const value_iterator &iter, const char *type, std::string_view detail, int delta, int depth_delta) noexcept {
   log_value(iter.json_iter(), type, detail, delta, depth_delta);
 }
 
-simdjson_really_inline void log_start_value(const value_iterator &iter, const char *type, int delta, int depth_delta) noexcept {
+inline void log_start_value(const value_iterator &iter, const char *type, int delta, int depth_delta) noexcept {
   log_start_value(iter.json_iter(), type, delta, depth_delta);
 }
 
-simdjson_really_inline void log_end_value(const value_iterator &iter, const char *type, int delta, int depth_delta) noexcept {
+inline void log_end_value(const value_iterator &iter, const char *type, int delta, int depth_delta) noexcept {
   log_end_value(iter.json_iter(), type, delta, depth_delta);
 }
 
-simdjson_really_inline void log_error(const value_iterator &iter, const char *error, const char *detail, int delta, int depth_delta) noexcept {
+inline void log_error(const value_iterator &iter, const char *error, const char *detail, int delta, int depth_delta) noexcept {
   log_error(iter.json_iter(), error, detail, delta, depth_delta);
 }
 
-simdjson_really_inline void log_headers() noexcept {
+inline void log_headers() noexcept {
   if (LOG_ENABLED) {
+    // Technically a static variable is not thread-safe, but if you are using threads
+    // and logging... well...
+    static bool displayed_hint{false};
     log_depth = 0;
+    printf("\n");
+    if(!displayed_hint) {
+      // We only print this helpful header once.
+      printf("# Logging provides the depth and position of the iterator user-visible steps:\n");
+      printf("# +array says 'this is where we were when we discovered the start array'\n");
+      printf("# -array says 'this is where we were when we ended the array'\n");
+      printf("# skip says 'this is a structural or value I am skipping'\n");
+      printf("# +/-skip says 'this is a start/end array or object I am skipping'\n");
+      printf("#\n");
+      printf("# The identation of the terms (array, string,...) indicates the depth,\n");
+      printf("# in addition to the depth being displayed.\n");
+      printf("#\n");
+      printf("# Every token in the document has a single depth determined by the tokens before it,\n");
+      printf("# and is not affected by what the token actually is.\n");
+      printf("#\n");
+      printf("# Not all structural elements are presented as tokens in the logs.\n");
+      printf("#\n");
+      printf("# We never give control to the user within an empty array or an empty object.\n");
+      printf("#\n");
+      printf("# Inside an array, having a depth greater than the array's depth means that\n");
+      printf("# we are pointing inside a value.\n");
+      printf("# Having a depth equal to the array means that we are pointing right before a value.\n");
+      printf("# Having a depth smaller than the array means that we have moved beyond the array.\n");
+      displayed_hint = true;
+    }
     printf("\n");
     printf("| %-*s ", LOG_EVENT_LEN,        "Event");
     printf("| %-*s ", LOG_BUFFER_LEN,       "Buffer");
@@ -21373,10 +24342,10 @@ simdjson_really_inline void log_headers() noexcept {
   }
 }
 
-simdjson_really_inline void log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept {
-  log_line(iter, iter.token.index+delta, depth_t(iter.depth()+depth_delta), title_prefix, title, detail);
+inline void log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept {
+  log_line(iter, iter.position()+delta, depth_t(iter.depth()+depth_delta), title_prefix, title, detail);
 }
-simdjson_really_inline void log_line(const json_iterator &iter, token_position index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept {
+inline void log_line(const json_iterator &iter, token_position index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept {
   if (LOG_ENABLED) {
     const int indent = depth*2;
     const auto buf = iter.token.buf;
@@ -21618,13 +24587,20 @@ namespace simdjson {
 namespace SIMDJSON_BUILTIN_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline token_iterator::token_iterator(const uint8_t *_buf, token_position _index) noexcept
-  : buf{_buf}, index{_index}
+simdjson_really_inline token_iterator::token_iterator(
+  const uint8_t *_buf,
+  token_position position
+) noexcept : buf{_buf}, _position{position}
 {
 }
 
-simdjson_really_inline const uint8_t *token_iterator::advance() noexcept {
-  return &buf[*(index++)];
+simdjson_really_inline uint32_t token_iterator::current_offset() const noexcept {
+  return *(_position);
+}
+
+
+simdjson_really_inline const uint8_t *token_iterator::return_current_and_advance() noexcept {
+  return &buf[*(_position++)];
 }
 
 simdjson_really_inline const uint8_t *token_iterator::peek(token_position position) const noexcept {
@@ -21638,39 +24614,39 @@ simdjson_really_inline uint32_t token_iterator::peek_length(token_position posit
 }
 
 simdjson_really_inline const uint8_t *token_iterator::peek(int32_t delta) const noexcept {
-  return &buf[*(index+delta)];
+  return &buf[*(_position+delta)];
 }
 simdjson_really_inline uint32_t token_iterator::peek_index(int32_t delta) const noexcept {
-  return *(index+delta);
+  return *(_position+delta);
 }
 simdjson_really_inline uint32_t token_iterator::peek_length(int32_t delta) const noexcept {
-  return *(index+delta+1) - *(index+delta);
+  return *(_position+delta+1) - *(_position+delta);
 }
 
 simdjson_really_inline token_position token_iterator::position() const noexcept {
-  return index;
+  return _position;
 }
-simdjson_really_inline void token_iterator::set_position(token_position target_checkpoint) noexcept {
-  index = target_checkpoint;
+simdjson_really_inline void token_iterator::set_position(token_position target_position) noexcept {
+  _position = target_position;
 }
 
 simdjson_really_inline bool token_iterator::operator==(const token_iterator &other) const noexcept {
-  return index == other.index;
+  return _position == other._position;
 }
 simdjson_really_inline bool token_iterator::operator!=(const token_iterator &other) const noexcept {
-  return index != other.index;
+  return _position != other._position;
 }
 simdjson_really_inline bool token_iterator::operator>(const token_iterator &other) const noexcept {
-  return index > other.index;
+  return _position > other._position;
 }
 simdjson_really_inline bool token_iterator::operator>=(const token_iterator &other) const noexcept {
-  return index >= other.index;
+  return _position >= other._position;
 }
 simdjson_really_inline bool token_iterator::operator<(const token_iterator &other) const noexcept {
-  return index < other.index;
+  return _position < other._position;
 }
 simdjson_really_inline bool token_iterator::operator<=(const token_iterator &other) const noexcept {
-  return index <= other.index;
+  return _position <= other._position;
 }
 
 } // namespace ondemand
@@ -21695,7 +24671,10 @@ simdjson_really_inline json_iterator::json_iterator(json_iterator &&other) noexc
   : token(std::forward<token_iterator>(other.token)),
     parser{other.parser},
     _string_buf_loc{other._string_buf_loc},
-    _depth{other._depth}
+    error{other.error},
+    _depth{other._depth},
+    _root{other._root},
+    _streaming{other._streaming}
 {
   other.parser = nullptr;
 }
@@ -21703,18 +24682,34 @@ simdjson_really_inline json_iterator &json_iterator::operator=(json_iterator &&o
   token = other.token;
   parser = other.parser;
   _string_buf_loc = other._string_buf_loc;
+  error = other.error;
   _depth = other._depth;
+  _root = other._root;
+  _streaming = other._streaming;
   other.parser = nullptr;
   return *this;
 }
 
 simdjson_really_inline json_iterator::json_iterator(const uint8_t *buf, ondemand::parser *_parser) noexcept
-  : token(buf, _parser->implementation->structural_indexes.get()),
+  : token(buf, &_parser->implementation->structural_indexes[0]),
     parser{_parser},
     _string_buf_loc{parser->string_buf.get()},
-    _depth{1}
+    _depth{1},
+    _root{parser->implementation->structural_indexes.get()},
+    _streaming{false}
+
 {
   logger::log_headers();
+#if SIMDJSON_CHECK_EOF
+  assert_more_tokens();
+#endif
+}
+
+inline void json_iterator::rewind() noexcept {
+  token.set_position( root_position() );
+  logger::log_headers(); // We start again
+  _string_buf_loc = parser->string_buf.get();
+  _depth = 1;
 }
 
 // GCC 7 warns when the first line of this function is inlined away into oblivion due to the caller
@@ -21723,9 +24718,19 @@ simdjson_really_inline json_iterator::json_iterator(const uint8_t *buf, ondemand
 SIMDJSON_PUSH_DISABLE_WARNINGS
 SIMDJSON_DISABLE_STRICT_OVERFLOW_WARNING
 simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child(depth_t parent_depth) noexcept {
+  /***
+   * WARNING:
+   * Inside an object, a string value is a depth of +1 compared to the object. Yet a key
+   * is at the same depth as the object.
+   * But json_iterator cannot easily tell whether we are pointing at a key or a string value.
+   * Instead, it assumes that if you are pointing at a string, then it is a value, not a key.
+   * To be clear...
+   * the following code assumes that we are *not* pointing at a key. If we are then a bug
+   * will follow. Unfortunately, it is not possible for the json_iterator its to make this
+   * check.
+   */
   if (depth() <= parent_depth) { return SUCCESS; }
-
-  switch (*advance()) {
+  switch (*return_current_and_advance()) {
     // TODO consider whether matching braces is a requirement: if non-matching braces indicates
     // *missing* braces, then future lookups are not in the object/arrays they think they are,
     // violating the rule "validate enough structure that the user can be confident they are
@@ -21746,7 +24751,24 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child
       logger::log_end_value(*this, "skip");
       _depth--;
       if (depth() <= parent_depth) { return SUCCESS; }
+#if SIMDJSON_CHECK_EOF
+      // If there are no more tokens, the parent is incomplete.
+      if (at_end()) { return report_error(INCOMPLETE_ARRAY_OR_OBJECT, "Missing [ or { at start"); }
+#endif // SIMDJSON_CHECK_EOF
       break;
+    /*case '"':
+      if(*peek() == ':') {
+        // we are at a key!!! This is
+        // only possible if someone searched
+        // for a key in an object and the key
+        // was not found but our code then
+        // decided the consume the separating
+        // comma before returning.
+        logger::log_value(*this, "key");
+        advance(); // eat up the ':'
+        break; // important!!!
+      }
+      simdjson_fallthrough;*/
     // Anything else must be a scalar value
     default:
       // For the first scalar, we will have incremented depth already, so we decrement it here.
@@ -21757,9 +24779,8 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child
   }
 
   // Now that we've considered the first value, we only increment/decrement for arrays/objects
-  auto end = &parser->implementation->structural_indexes[parser->implementation->n_structural_indexes];
-  while (token.index <= end) {
-    switch (*advance()) {
+  while (position() < end_position()) {
+    switch (*return_current_and_advance()) {
       case '[': case '{':
         logger::log_start_value(*this, "skip");
         _depth++;
@@ -21786,23 +24807,53 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child
 SIMDJSON_POP_DISABLE_WARNINGS
 
 simdjson_really_inline bool json_iterator::at_root() const noexcept {
-  return token.position() == root_checkpoint();
+  return position() == root_position();
 }
 
-simdjson_really_inline token_position json_iterator::root_checkpoint() const noexcept {
-  return parser->implementation->structural_indexes.get();
+simdjson_really_inline bool json_iterator::streaming() const noexcept {
+  return _streaming;
+}
+
+simdjson_really_inline token_position json_iterator::root_position() const noexcept {
+  return _root;
 }
 
 simdjson_really_inline void json_iterator::assert_at_root() const noexcept {
   SIMDJSON_ASSUME( _depth == 1 );
-  // Visual Studio Clang treats unique_ptr.get() as "side effecting."
 #ifndef SIMDJSON_CLANG_VISUAL_STUDIO
-  SIMDJSON_ASSUME( token.index == parser->implementation->structural_indexes.get() );
+  // Under Visual Studio, the next SIMDJSON_ASSUME fails with: the argument
+  // has side effects that will be discarded.
+  SIMDJSON_ASSUME( token.position() == _root );
 #endif
 }
 
-simdjson_really_inline bool json_iterator::at_eof() const noexcept {
-  return token.index == &parser->implementation->structural_indexes[parser->implementation->n_structural_indexes];
+simdjson_really_inline void json_iterator::assert_more_tokens(uint32_t required_tokens) const noexcept {
+  assert_valid_position(token._position + required_tokens - 1);
+}
+
+simdjson_really_inline void json_iterator::assert_valid_position(token_position position) const noexcept {
+#ifndef SIMDJSON_CLANG_VISUAL_STUDIO
+  SIMDJSON_ASSUME( position >= &parser->implementation->structural_indexes[0] );
+  SIMDJSON_ASSUME( position < &parser->implementation->structural_indexes[parser->implementation->n_structural_indexes] );
+#endif
+}
+
+simdjson_really_inline bool json_iterator::at_end() const noexcept {
+  return position() == end_position();
+}
+simdjson_really_inline token_position json_iterator::end_position() const noexcept {
+  uint32_t n_structural_indexes{parser->implementation->n_structural_indexes};
+  return &parser->implementation->structural_indexes[n_structural_indexes];
+}
+
+inline std::string json_iterator::to_string() const noexcept {
+  if( !is_alive() ) { return "dead json_iterator instance"; }
+  const char * current_structural = reinterpret_cast<const char *>(token.peek());
+  return std::string("json_iterator [ depth : ") + std::to_string(_depth)
+          + std::string(", structural : '") + std::string(current_structural,1)
+          + std::string("', offset : ") + std::to_string(token.current_offset())
+          + std::string("', error : ") + error_message(error)
+          + std::string(" ]");
 }
 
 simdjson_really_inline bool json_iterator::is_alive() const noexcept {
@@ -21814,27 +24865,49 @@ simdjson_really_inline void json_iterator::abandon() noexcept {
   _depth = 0;
 }
 
-simdjson_really_inline const uint8_t *json_iterator::advance() noexcept {
-  return token.advance();
+simdjson_really_inline const uint8_t *json_iterator::return_current_and_advance() noexcept {
+#if SIMDJSON_CHECK_EOF
+  assert_more_tokens();
+#endif // SIMDJSON_CHECK_EOF
+  return token.return_current_and_advance();
+}
+
+simdjson_really_inline const uint8_t *json_iterator::unsafe_pointer() const noexcept {
+  // deliberately done without safety guard:
+  return token.peek(0);
 }
 
 simdjson_really_inline const uint8_t *json_iterator::peek(int32_t delta) const noexcept {
+#if SIMDJSON_CHECK_EOF
+  assert_more_tokens(delta+1);
+#endif // SIMDJSON_CHECK_EOF
   return token.peek(delta);
 }
 
 simdjson_really_inline uint32_t json_iterator::peek_length(int32_t delta) const noexcept {
+#if SIMDJSON_CHECK_EOF
+  assert_more_tokens(delta+1);
+#endif // #if SIMDJSON_CHECK_EOF
   return token.peek_length(delta);
 }
 
 simdjson_really_inline const uint8_t *json_iterator::peek(token_position position) const noexcept {
+  // todo: currently we require end-of-string buffering, but the following
+  // assert_valid_position should be turned on if/when we lift that condition.
+  // assert_valid_position(position);
+  // This is almost surely related to SIMDJSON_CHECK_EOF but given that SIMDJSON_CHECK_EOF
+  // is ON by default, we have no choice but to disable it for real with a comment.
   return token.peek(position);
 }
 
 simdjson_really_inline uint32_t json_iterator::peek_length(token_position position) const noexcept {
+#if SIMDJSON_CHECK_EOF
+  assert_valid_position(position);
+#endif // SIMDJSON_CHECK_EOF
   return token.peek_length(position);
 }
 
-simdjson_really_inline token_position json_iterator::last_document_position() const noexcept {
+simdjson_really_inline token_position json_iterator::last_position() const noexcept {
   // The following line fails under some compilers...
   // SIMDJSON_ASSUME(parser->implementation->n_structural_indexes > 0);
   // since it has side-effects.
@@ -21843,7 +24916,7 @@ simdjson_really_inline token_position json_iterator::last_document_position() co
   return &parser->implementation->structural_indexes[n_structural_indexes - 1];
 }
 simdjson_really_inline const uint8_t *json_iterator::peek_last() const noexcept {
-  return token.peek(last_document_position());
+  return token.peek(last_position());
 }
 
 simdjson_really_inline void json_iterator::ascend_to(depth_t parent_depth) noexcept {
@@ -21876,6 +24949,7 @@ simdjson_really_inline error_code json_iterator::report_error(error_code _error,
 simdjson_really_inline token_position json_iterator::position() const noexcept {
   return token.position();
 }
+
 simdjson_really_inline void json_iterator::reenter_child(token_position position, depth_t child_depth) noexcept {
   SIMDJSON_ASSUME(child_depth >= 1 && child_depth < INT32_MAX);
   SIMDJSON_ASSUME(_depth == child_depth - 1);
@@ -21889,9 +24963,11 @@ simdjson_really_inline void json_iterator::reenter_child(token_position position
 }
 
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
+
 simdjson_really_inline token_position json_iterator::start_position(depth_t depth) const noexcept {
   return parser->start_positions[depth];
 }
+
 simdjson_really_inline void json_iterator::set_start_position(depth_t depth, token_position position) noexcept {
   parser->start_positions[depth] = position;
 }
@@ -21907,9 +24983,11 @@ simdjson_really_inline error_code json_iterator::optional_error(error_code _erro
 
 template<int N>
 simdjson_warn_unused simdjson_really_inline bool json_iterator::copy_to_buffer(const uint8_t *json, uint32_t max_len, uint8_t (&tmpbuf)[N]) noexcept {
+  // Let us guard against silly cases:
+  if((N < max_len) || (N == 0)) { return false; }
   // Truncate whitespace to fit the buffer.
   if (max_len > N-1) {
-    if (jsoncharutils::is_not_structural_or_whitespace(json[N-1])) { return false; }
+    // if (jsoncharutils::is_not_structural_or_whitespace(json[N-1])) { return false; }
     max_len = N-1;
   }
 
@@ -21917,20 +24995,6 @@ simdjson_warn_unused simdjson_really_inline bool json_iterator::copy_to_buffer(c
   std::memcpy(tmpbuf, json, max_len);
   tmpbuf[max_len] = ' ';
   return true;
-}
-
-template<int N>
-simdjson_warn_unused simdjson_really_inline bool json_iterator::peek_to_buffer(uint8_t (&tmpbuf)[N]) noexcept {
-  auto max_len = token.peek_length();
-  auto json = token.peek();
-  return copy_to_buffer(json, max_len, tmpbuf);
-}
-
-template<int N>
-simdjson_warn_unused simdjson_really_inline bool json_iterator::advance_to_buffer(uint8_t (&tmpbuf)[N]) noexcept {
-  auto max_len = peek_length();
-  auto json = advance();
-  return copy_to_buffer(json, max_len, tmpbuf);
 }
 
 } // namespace ondemand
@@ -21951,54 +25015,72 @@ namespace simdjson {
 namespace SIMDJSON_BUILTIN_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline value_iterator::value_iterator(json_iterator *json_iter, depth_t depth, token_position start_index) noexcept
-  : _json_iter{json_iter},
-    _depth{depth},
-    _start_position{start_index}
+simdjson_really_inline value_iterator::value_iterator(
+  json_iterator *json_iter,
+  depth_t depth,
+  token_position start_position
+) noexcept : _json_iter{json_iter}, _depth{depth}, _start_position{start_position}
 {
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::start_object() noexcept {
-  const uint8_t *json;
-  SIMDJSON_TRY( advance_container_start("object", json) );
-  if (*json != '{') { return incorrect_type_error("Not an object"); }
+  SIMDJSON_TRY( start_container('{', "Not an object", "object") );
   return started_object();
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::start_root_object() noexcept {
-  bool result;
-  SIMDJSON_TRY( start_object().get(result) );
-  if (*_json_iter->peek_last() != '}') { return _json_iter->report_error(TAPE_ERROR, "object invalid: { at beginning of document unmatched by } at end of document"); }
-  return result;
+  SIMDJSON_TRY( start_container('{', "Not an object", "object") );
+  return started_root_object();
 }
 
-simdjson_warn_unused simdjson_really_inline bool value_iterator::started_object() noexcept {
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::started_object() noexcept {
   assert_at_container_start();
+#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+  _json_iter->set_start_position(_depth, start_position());
+#endif
   if (*_json_iter->peek() == '}') {
     logger::log_value(*_json_iter, "empty object");
-    _json_iter->advance();
-    _json_iter->ascend_to(depth()-1);
+    _json_iter->return_current_and_advance();
+    end_container();
     return false;
   }
-  logger::log_start_value(*_json_iter, "object");
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
-  _json_iter->set_start_position(_depth, _start_position);
-#endif
   return true;
+}
+
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::started_root_object() noexcept {
+  // When in streaming mode, we cannot expect peek_last() to be the last structural element of the
+  // current document. It only works in the normal mode where we have indexed a single document.
+  // Note that adding a check for 'streaming' is not expensive since we only have at most
+  // one root element.
+  if (! _json_iter->streaming() && (*_json_iter->peek_last() != '}')) {
+    return report_error(INCOMPLETE_ARRAY_OR_OBJECT, "missing } at end");
+  }
+  return started_object();
+}
+
+simdjson_warn_unused simdjson_really_inline error_code value_iterator::end_container() noexcept {
+#if SIMDJSON_CHECK_EOF
+    if (depth() > 1 && at_end()) { return report_error(INCOMPLETE_ARRAY_OR_OBJECT, "missing parent ] or }"); }
+    // if (depth() <= 1 && !at_end()) { return report_error(INCOMPLETE_ARRAY_OR_OBJECT, "missing [ or { at start"); }
+#endif // SIMDJSON_CHECK_EOF
+    _json_iter->ascend_to(depth()-1);
+    return SUCCESS;
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::has_next_field() noexcept {
   assert_at_next();
 
-  switch (*_json_iter->advance()) {
+  // It's illegal to call this unless there are more tokens: anything that ends in } or ] is
+  // obligated to verify there are more tokens if they are not the top level.
+  switch (*_json_iter->return_current_and_advance()) {
     case '}':
       logger::log_end_value(*_json_iter, "object");
-      _json_iter->ascend_to(depth()-1);
+      SIMDJSON_TRY( end_container() );
       return false;
     case ',':
       return true;
     default:
-      return _json_iter->report_error(TAPE_ERROR, "Missing comma between object fields");
+      return report_error(TAPE_ERROR, "Missing comma between object fields");
   }
 }
 
@@ -22014,7 +25096,6 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   //    { "a": [ 1, 2 ], "b": [ 3, 4 ] }
   //      ^ (depth 2, index 1)
   //    ```
-  //
   if (at_first_field()) {
     has_value = true;
 
@@ -22035,7 +25116,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
     // this object iterator will blithely scan that object for fields.
     if (_json_iter->depth() < depth() - 1) { return OUT_OF_ORDER_ITERATION; }
 #endif
-    has_value = false;
+    return false;
 
   // 3. When a previous search found a field or an iterator yielded a value:
   //
@@ -22055,15 +25136,19 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
     if ((error = skip_child() )) { abandon(); return error; }
     if ((error = has_next_field().get(has_value) )) { abandon(); return error; }
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
-    if (_json_iter->start_position(_depth) != _start_position) { return OUT_OF_ORDER_ITERATION; }
+    if (_json_iter->start_position(_depth) != start_position()) { return OUT_OF_ORDER_ITERATION; }
 #endif
   }
   while (has_value) {
     // Get the key and colon, stopping at the value.
     raw_json_string actual_key;
     // size_t max_key_length = _json_iter->peek_length() - 2; // -2 for the two quotes
+    // Note: _json_iter->peek_length() - 2 might overflow if _json_iter->peek_length() < 2.
+    // field_key() advances the pointer and checks that '"' is found (corresponding to a key).
+    // The depth is left unchanged by field_key().
     if ((error = field_key().get(actual_key) )) { abandon(); return error; };
-
+    // field_value() will advance and check that we find a ':' separating the
+    // key and the value. It will also increment the depth by one.
     if ((error = field_value() )) { abandon(); return error; }
     // If it matches, stop and return
     // We could do it this way if we wanted to allow arbitrary
@@ -22075,12 +25160,18 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
     // input).
     if (actual_key.unsafe_is_equal(key)) {
       logger::log_event(*this, "match", key, -2);
+      // If we return here, then we return while pointing at the ':' that we just checked.
       return true;
     }
 
     // No match: skip the value and see if , or } is next
     logger::log_event(*this, "no match", key, -2);
+    // The call to skip_child is meant to skip over the value corresponding to the key.
+    // After skip_child(), we are right before the next comma (',') or the final brace ('}').
     SIMDJSON_TRY( skip_child() ); // Skip the value entirely
+    // The has_next_field() advances the pointer and check that either ',' or '}' is found.
+    // It returns true if ',' is found, false otherwise. If anything other than ',' or '}' is found,
+    // then we are in error and we abort.
     if ((error = has_next_field().get(has_value) )) { abandon(); return error; }
   }
 
@@ -22089,20 +25180,33 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::find_field_unordered_raw(const std::string_view key) noexcept {
+  /**
+   * When find_field_unordered_raw is called, we can either be pointing at the
+   * first key, pointing outside (at the closing brace) or if a key was matched
+   * we can be either pointing right afterthe ':' right before the value (that we need skip),
+   * or we may have consumed the value and we might be at a comma or at the
+   * final brace (ready for a call to has_next_field()).
+   */
   error_code error;
   bool has_value;
-  //
+
+  // First, we scan from that point to the end.
+  // If we don't find a match, we may loop back around, and scan from the beginning to that point.
+  token_position search_start = _json_iter->position();
+
+  // We want to know whether we need to go back to the beginning.
+  bool at_first = at_first_field();
+  ///////////////
   // Initially, the object can be in one of a few different places:
   //
-  // 1. The start of the object, at the first field:
+  // 1. At the first key:
   //
   //    ```
   //    { "a": [ 1, 2 ], "b": [ 3, 4 ] }
   //      ^ (depth 2, index 1)
   //    ```
   //
-  if (at_first_field()) {
-    // If we're at the beginning of the object, we definitely have a field
+  if (at_first) {
     has_value = true;
 
   // 2. When a previous search did not yield a value or the object is empty:
@@ -22115,14 +25219,15 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   //    ```
   //
   } else if (!is_open()) {
+
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
     // If we're past the end of the object, we're being iterated out of order.
     // Note: this isn't perfect detection. It's possible the user is inside some other object; if so,
     // this object iterator will blithely scan that object for fields.
     if (_json_iter->depth() < depth() - 1) { return OUT_OF_ORDER_ITERATION; }
 #endif
-    has_value = false;
-
+    SIMDJSON_TRY(reset_object().get(has_value));
+    at_first = true;
   // 3. When a previous search found a field or an iterator yielded a value:
   //
   //    ```
@@ -22138,11 +25243,14 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   //    ```
   //
   } else {
-    // Finish the previous value and see if , or } is next
+    // If someone queried a key but they not did access the value, then we are left pointing
+    // at the ':' and we need to move forward through the value... If the value was
+    // processed then skip_child() does not move the iterator (but may adjust the depth).
     if ((error = skip_child() )) { abandon(); return error; }
+    search_start = _json_iter->position();
     if ((error = has_next_field().get(has_value) )) { abandon(); return error; }
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
-    if (_json_iter->start_position(_depth) != _start_position) { return OUT_OF_ORDER_ITERATION; }
+    if (_json_iter->start_position(_depth) != start_position()) { return OUT_OF_ORDER_ITERATION; }
 #endif
   }
 
@@ -22159,11 +25267,6 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   //                                  ^ (depth 0)
   // ```
   //
-
-  // First, we scan from that point to the end.
-  // If we don't find a match, we loop back around, and scan from the beginning to that point.
-  token_position search_start = _json_iter->position();
-
   // Next, we find a match starting from the current position.
   while (has_value) {
     SIMDJSON_ASSUME( _json_iter->_depth == _depth ); // We must be at the start of a field
@@ -22171,8 +25274,12 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
     // Get the key and colon, stopping at the value.
     raw_json_string actual_key;
     // size_t max_key_length = _json_iter->peek_length() - 2; // -2 for the two quotes
-
+    // Note: _json_iter->peek_length() - 2 might overflow if _json_iter->peek_length() < 2.
+    // field_key() advances the pointer and checks that '"' is found (corresponding to a key).
+    // The depth is left unchanged by field_key().
     if ((error = field_key().get(actual_key) )) { abandon(); return error; };
+    // field_value() will advance and check that we find a ':' separating the
+    // key and the value. It will also increment the depth by one.
     if ((error = field_value() )) { abandon(); return error; }
 
     // If it matches, stop and return
@@ -22185,31 +25292,44 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
     // input).
     if (actual_key.unsafe_is_equal(key)) {
       logger::log_event(*this, "match", key, -2);
+      // If we return here, then we return while pointing at the ':' that we just checked.
       return true;
     }
 
     // No match: skip the value and see if , or } is next
     logger::log_event(*this, "no match", key, -2);
+    // The call to skip_child is meant to skip over the value corresponding to the key.
+    // After skip_child(), we are right before the next comma (',') or the final brace ('}').
     SIMDJSON_TRY( skip_child() );
+    // The has_next_field() advances the pointer and check that either ',' or '}' is found.
+    // It returns true if ',' is found, false otherwise. If anything other than ',' or '}' is found,
+    // then we are in error and we abort.
     if ((error = has_next_field().get(has_value) )) { abandon(); return error; }
   }
+  // Performance note: it maybe wasteful to rewind to the beginning when there might be
+  // no other query following. Indeed, it would require reskipping the whole object.
+  // Instead, you can just stay where you are. If there is a new query, there is always time
+  // to rewind.
+  if(at_first) { return false; }
 
   // If we reach the end without finding a match, search the rest of the fields starting at the
   // beginning of the object.
   // (We have already run through the object before, so we've already validated its structure. We
   // don't check errors in this bit.)
-  _json_iter->reenter_child(_start_position + 1, _depth);
-
-  has_value = started_object();
-  while (_json_iter->position() < search_start) {
+  SIMDJSON_TRY(reset_object().get(has_value));
+  while (true) {
     SIMDJSON_ASSUME(has_value); // we should reach search_start before ever reaching the end of the object
     SIMDJSON_ASSUME( _json_iter->_depth == _depth ); // We must be at the start of a field
 
     // Get the key and colon, stopping at the value.
     raw_json_string actual_key;
     // size_t max_key_length = _json_iter->peek_length() - 2; // -2 for the two quotes
-
+    // Note: _json_iter->peek_length() - 2 might overflow if _json_iter->peek_length() < 2.
+    // field_key() advances the pointer and checks that '"' is found (corresponding to a key).
+    // The depth is left unchanged by field_key().
     error = field_key().get(actual_key); SIMDJSON_ASSUME(!error);
+    // field_value() will advance and check that we find a ':' separating the
+    // key and the value.  It will also increment the depth by one.
     error = field_value(); SIMDJSON_ASSUME(!error);
 
     // If it matches, stop and return
@@ -22222,78 +25342,104 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
     // input).
     if (actual_key.unsafe_is_equal(key)) {
       logger::log_event(*this, "match", key, -2);
+      // If we return here, then we return while pointing at the ':' that we just checked.
       return true;
     }
 
     // No match: skip the value and see if , or } is next
     logger::log_event(*this, "no match", key, -2);
+    // The call to skip_child is meant to skip over the value corresponding to the key.
+    // After skip_child(), we are right before the next comma (',') or the final brace ('}').
     SIMDJSON_TRY( skip_child() );
+    // If we reached the end of the key-value pair we started from, then we know
+    // that the key is not there so we return false. We are either right before
+    // the next comma or the final brace.
+    if(_json_iter->position() == search_start) { return false; }
+    // The has_next_field() advances the pointer and check that either ',' or '}' is found.
+    // It returns true if ',' is found, false otherwise. If anything other than ',' or '}' is found,
+    // then we are in error and we abort.
     error = has_next_field().get(has_value); SIMDJSON_ASSUME(!error);
+    // If we make the mistake of exiting here, then we could be left pointing at a key
+    // in the middle of an object. That's not an allowable state.
   }
-
-  // If the loop ended, we're out of fields to look at.
+  // If the loop ended, we're out of fields to look at. The program should
+  // never reach this point.
   return false;
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::field_key() noexcept {
   assert_at_next();
 
-  const uint8_t *key = _json_iter->advance();
-  if (*(key++) != '"') { return _json_iter->report_error(TAPE_ERROR, "Object key is not a string"); }
+  const uint8_t *key = _json_iter->return_current_and_advance();
+  if (*(key++) != '"') { return report_error(TAPE_ERROR, "Object key is not a string"); }
   return raw_json_string(key);
 }
 
 simdjson_warn_unused simdjson_really_inline error_code value_iterator::field_value() noexcept {
   assert_at_next();
 
-  if (*_json_iter->advance() != ':') { return _json_iter->report_error(TAPE_ERROR, "Missing colon in object field"); }
+  if (*_json_iter->return_current_and_advance() != ':') { return report_error(TAPE_ERROR, "Missing colon in object field"); }
   _json_iter->descend_to(depth()+1);
   return SUCCESS;
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::start_array() noexcept {
-  const uint8_t *json;
-  SIMDJSON_TRY( advance_container_start("array", json) );
-  if (*json != '[') { return incorrect_type_error("Not an array"); }
+  SIMDJSON_TRY( start_container('[', "Not an array", "array") );
   return started_array();
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::start_root_array() noexcept {
-  bool result;
-  SIMDJSON_TRY( start_array().get(result) );
-  if (*_json_iter->peek_last() != ']') { return _json_iter->report_error(TAPE_ERROR, "array invalid: [ at beginning of document unmatched by ] at end of document"); }
-  return result;
+  SIMDJSON_TRY( start_container('[', "Not an array", "array") );
+  return started_root_array();
 }
 
-simdjson_warn_unused simdjson_really_inline bool value_iterator::started_array() noexcept {
+inline std::string value_iterator::to_string() const noexcept {
+  auto answer = std::string("value_iterator [ depth : ") + std::to_string(_depth) + std::string(", ");
+  if(_json_iter != nullptr) { answer +=  _json_iter->to_string(); }
+  answer += std::string(" ]");
+  return answer;
+}
+
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::started_array() noexcept {
   assert_at_container_start();
   if (*_json_iter->peek() == ']') {
     logger::log_value(*_json_iter, "empty array");
-    _json_iter->advance();
-    _json_iter->ascend_to(depth()-1);
+    _json_iter->return_current_and_advance();
+    SIMDJSON_TRY( end_container() );
     return false;
   }
-  logger::log_start_value(*_json_iter, "array");
   _json_iter->descend_to(depth()+1);
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
-  _json_iter->set_start_position(_depth, _start_position);
+  _json_iter->set_start_position(_depth, start_position());
 #endif
   return true;
+}
+
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::started_root_array() noexcept {
+  // When in streaming mode, we cannot expect peek_last() to be the last structural element of the
+  // current document. It only works in the normal mode where we have indexed a single document.
+  // Note that adding a check for 'streaming' is not expensive since we only have at most
+  // one root element.
+  if ( ! _json_iter->streaming() && (*_json_iter->peek_last() != ']')) {
+    return report_error(INCOMPLETE_ARRAY_OR_OBJECT, "missing ] at end");
+  }
+  return started_array();
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::has_next_element() noexcept {
   assert_at_next();
 
-  switch (*_json_iter->advance()) {
+  logger::log_event(*this, "has_next_element");
+  switch (*_json_iter->return_current_and_advance()) {
     case ']':
       logger::log_end_value(*_json_iter, "array");
-      _json_iter->ascend_to(depth()-1);
+      SIMDJSON_TRY( end_container() );
       return false;
     case ',':
       _json_iter->descend_to(depth()+1);
       return true;
     default:
-      return _json_iter->report_error(TAPE_ERROR, "Missing comma between array elements");
+      return report_error(TAPE_ERROR, "Missing comma between array elements");
   }
 }
 
@@ -22312,24 +25458,50 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> va
   return get_raw_json_string().unescape(_json_iter->string_buf_loc());
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::get_raw_json_string() noexcept {
-  auto json = advance_start("string");
+  auto json = peek_scalar("string");
   if (*json != '"') { return incorrect_type_error("Not a string"); }
+  advance_scalar("string");
   return raw_json_string(json+1);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::get_uint64() noexcept {
-  return numberparsing::parse_unsigned(advance_non_root_scalar("uint64"));
+  auto result = numberparsing::parse_unsigned(peek_non_root_scalar("uint64"));
+  if(result.error() != INCORRECT_TYPE) { advance_non_root_scalar("uint64"); }
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::get_uint64_in_string() noexcept {
+  auto result = numberparsing::parse_unsigned_in_string(peek_non_root_scalar("uint64"));
+  if(result.error() != INCORRECT_TYPE) { advance_non_root_scalar("uint64"); }
+  return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::get_int64() noexcept {
-  return numberparsing::parse_integer(advance_non_root_scalar("int64"));
+  auto result = numberparsing::parse_integer(peek_non_root_scalar("int64"));
+  if(result.error() != INCORRECT_TYPE) { advance_non_root_scalar("int64"); }
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::get_int64_in_string() noexcept {
+  auto result = numberparsing::parse_integer_in_string(peek_non_root_scalar("int64"));
+  if(result.error() != INCORRECT_TYPE) { advance_non_root_scalar("int64"); }
+  return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::get_double() noexcept {
-  return numberparsing::parse_double(advance_non_root_scalar("double"));
+  auto result = numberparsing::parse_double(peek_non_root_scalar("double"));
+  if(result.error() != INCORRECT_TYPE) { advance_non_root_scalar("double"); }
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::get_double_in_string() noexcept {
+  auto result = numberparsing::parse_double_in_string(peek_non_root_scalar("double"));
+  if(result.error() != INCORRECT_TYPE) { advance_non_root_scalar("double"); }
+  return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::get_bool() noexcept {
-  return parse_bool(advance_non_root_scalar("bool"));
+  auto result = parse_bool(peek_non_root_scalar("bool"));
+  if(result.error() != INCORRECT_TYPE) { advance_non_root_scalar("bool"); }
+  return result;
 }
 simdjson_really_inline bool value_iterator::is_null() noexcept {
-  return parse_null(advance_non_root_scalar("null"));
+  auto result = parse_null(peek_non_root_scalar("null"));
+  if(result) { advance_non_root_scalar("null"); }
+  return result;
 }
 
 constexpr const uint32_t MAX_INT_LENGTH = 1024;
@@ -22342,42 +25514,103 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> val
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::get_root_uint64() noexcept {
   auto max_len = peek_start_length();
-  auto json = advance_root_scalar("uint64");
+  auto json = peek_root_scalar("uint64");
   uint8_t tmpbuf[20+1]; // <20 digits> is the longest possible unsigned integer
-  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, _start_position, depth(), "Root number more than 20 characters"); return NUMBER_ERROR; }
-  return numberparsing::parse_unsigned(tmpbuf);
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) {
+    logger::log_error(*_json_iter, start_position(), depth(), "Root number more than 20 characters");
+    return NUMBER_ERROR;
+  }
+  auto result = numberparsing::parse_unsigned(tmpbuf);
+  if(result.error() != INCORRECT_TYPE) { advance_root_scalar("uint64"); }
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::get_root_uint64_in_string() noexcept {
+  auto max_len = peek_start_length();
+  auto json = peek_root_scalar("uint64");
+  uint8_t tmpbuf[20+1]; // <20 digits> is the longest possible unsigned integer
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) {
+    logger::log_error(*_json_iter, start_position(), depth(), "Root number more than 20 characters");
+    return NUMBER_ERROR;
+  }
+  auto result = numberparsing::parse_unsigned_in_string(tmpbuf);
+  if(result.error() != INCORRECT_TYPE) { advance_root_scalar("uint64"); }
+  return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::get_root_int64() noexcept {
   auto max_len = peek_start_length();
-  auto json = advance_root_scalar("int64");
+  auto json = peek_root_scalar("int64");
   uint8_t tmpbuf[20+1]; // -<19 digits> is the longest possible integer
-  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, _start_position, depth(), "Root number more than 20 characters"); return NUMBER_ERROR; }
-  return numberparsing::parse_integer(tmpbuf);
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) {
+    logger::log_error(*_json_iter, start_position(), depth(), "Root number more than 20 characters");
+    return NUMBER_ERROR;
+  }
+
+  auto result = numberparsing::parse_integer(tmpbuf);
+  if(result.error() != INCORRECT_TYPE) { advance_root_scalar("int64"); }
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::get_root_int64_in_string() noexcept {
+  auto max_len = peek_start_length();
+  auto json = peek_root_scalar("int64");
+  uint8_t tmpbuf[20+1]; // -<19 digits> is the longest possible integer
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) {
+    logger::log_error(*_json_iter, start_position(), depth(), "Root number more than 20 characters");
+    return NUMBER_ERROR;
+  }
+
+  auto result = numberparsing::parse_integer_in_string(tmpbuf);
+  if(result.error() != INCORRECT_TYPE) { advance_root_scalar("int64"); }
+  return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::get_root_double() noexcept {
   auto max_len = peek_start_length();
-  auto json = advance_root_scalar("double");
-  // Per https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/, 1074 is the maximum number of significant fractional digits. Add 8 more digits for the biggest number: -0.<fraction>e-308.
+  auto json = peek_root_scalar("double");
+  // Per https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/,
+  // 1074 is the maximum number of significant fractional digits. Add 8 more digits for the biggest
+  // number: -0.<fraction>e-308.
   uint8_t tmpbuf[1074+8+1];
-  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, _start_position, depth(), "Root number more than 1082 characters"); return NUMBER_ERROR; }
-  return numberparsing::parse_double(tmpbuf);
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) {
+    logger::log_error(*_json_iter, start_position(), depth(), "Root number more than 1082 characters");
+    return NUMBER_ERROR;
+  }
+  auto result = numberparsing::parse_double(tmpbuf);
+  if(result.error() != INCORRECT_TYPE) { advance_root_scalar("double"); }
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::get_root_double_in_string() noexcept {
+  auto max_len = peek_start_length();
+  auto json = peek_root_scalar("double");
+  // Per https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/,
+  // 1074 is the maximum number of significant fractional digits. Add 8 more digits for the biggest
+  // number: -0.<fraction>e-308.
+  uint8_t tmpbuf[1074+8+1];
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) {
+    logger::log_error(*_json_iter, start_position(), depth(), "Root number more than 1082 characters");
+    return NUMBER_ERROR;
+  }
+  auto result = numberparsing::parse_double_in_string(tmpbuf);
+  if(result.error() != INCORRECT_TYPE) { advance_root_scalar("double"); }
+  return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::get_root_bool() noexcept {
   auto max_len = peek_start_length();
-  auto json = advance_root_scalar("bool");
+  auto json = peek_root_scalar("bool");
   uint8_t tmpbuf[5+1];
   if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { return incorrect_type_error("Not a boolean"); }
+  advance_root_scalar("bool");
   return parse_bool(tmpbuf);
 }
 simdjson_really_inline bool value_iterator::is_root_null() noexcept {
   auto max_len = peek_start_length();
-  auto json = advance_root_scalar("null");
-  return max_len >= 4 && !atomparsing::str4ncmp(json, "null") &&
-         (max_len == 4 || jsoncharutils::is_structural_or_whitespace(json[5]));
+  auto json = peek_root_scalar("null");
+  auto result = (max_len >= 4 && !atomparsing::str4ncmp(json, "null") &&
+         (max_len == 4 || jsoncharutils::is_structural_or_whitespace(json[5])));
+  if(result) { advance_root_scalar("null"); }
+  return result;
 }
 
 simdjson_warn_unused simdjson_really_inline error_code value_iterator::skip_child() noexcept {
-  SIMDJSON_ASSUME( _json_iter->token.index > _start_position );
+  SIMDJSON_ASSUME( _json_iter->token._position > _start_position );
   SIMDJSON_ASSUME( _json_iter->_depth >= _depth );
 
   return _json_iter->skip_child(depth());
@@ -22398,17 +25631,17 @@ simdjson_really_inline bool value_iterator::is_open() const noexcept {
 }
 SIMDJSON_POP_DISABLE_WARNINGS
 
-simdjson_really_inline bool value_iterator::at_eof() const noexcept {
-  return _json_iter->at_eof();
+simdjson_really_inline bool value_iterator::at_end() const noexcept {
+  return _json_iter->at_end();
 }
 
 simdjson_really_inline bool value_iterator::at_start() const noexcept {
-  return _json_iter->token.index == _start_position;
+  return _json_iter->token.position() == start_position();
 }
 
 simdjson_really_inline bool value_iterator::at_first_field() const noexcept {
-  SIMDJSON_ASSUME( _json_iter->token.index > _start_position );
-  return _json_iter->token.index == _start_position + 1;
+  SIMDJSON_ASSUME( _json_iter->token._position > _start_position );
+  return _json_iter->token.position() == start_position() + 1;
 }
 
 simdjson_really_inline void value_iterator::abandon() noexcept {
@@ -22432,111 +25665,169 @@ simdjson_warn_unused simdjson_really_inline json_iterator &value_iterator::json_
 }
 
 simdjson_really_inline const uint8_t *value_iterator::peek_start() const noexcept {
-  return _json_iter->peek(_start_position);
+  return _json_iter->peek(start_position());
 }
 simdjson_really_inline uint32_t value_iterator::peek_start_length() const noexcept {
-  return _json_iter->peek_length(_start_position);
+  return _json_iter->peek_length(start_position());
 }
 
-simdjson_really_inline const uint8_t *value_iterator::advance_start(const char *type) const noexcept {
-  logger::log_value(*_json_iter, _start_position, depth(), type);
+simdjson_really_inline const uint8_t *value_iterator::peek_scalar(const char *type) noexcept {
+  logger::log_value(*_json_iter, start_position(), depth(), type);
   // If we're not at the position anymore, we don't want to advance the cursor.
   if (!is_at_start()) { return peek_start(); }
 
   // Get the JSON and advance the cursor, decreasing depth to signify that we have retrieved the value.
   assert_at_start();
-  auto result = _json_iter->advance();
-  _json_iter->ascend_to(depth()-1);
-  return result;
+  return _json_iter->peek();
 }
-simdjson_really_inline error_code value_iterator::advance_container_start(const char *type, const uint8_t *&json) const noexcept {
-  logger::log_start_value(*_json_iter, _start_position, depth(), type);
 
+simdjson_really_inline void value_iterator::advance_scalar(const char *type) noexcept {
+  logger::log_value(*_json_iter, start_position(), depth(), type);
   // If we're not at the position anymore, we don't want to advance the cursor.
+  if (!is_at_start()) { return; }
+
+  // Get the JSON and advance the cursor, decreasing depth to signify that we have retrieved the value.
+  assert_at_start();
+  _json_iter->return_current_and_advance();
+  _json_iter->ascend_to(depth()-1);
+}
+
+simdjson_really_inline error_code value_iterator::start_container(uint8_t start_char, const char *incorrect_type_message, const char *type) noexcept {
+  logger::log_start_value(*_json_iter, start_position(), depth(), type);
+  // If we're not at the position anymore, we don't want to advance the cursor.
+  const uint8_t *json;
   if (!is_at_start()) {
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
     if (!is_at_iterator_start()) { return OUT_OF_ORDER_ITERATION; }
 #endif
     json = peek_start();
-    return SUCCESS;
+    if (*json != start_char) { return incorrect_type_error(incorrect_type_message); }
+  } else {
+    assert_at_start();
+    /**
+     * We should be prudent. Let us peek. If it is not the right type, we
+     * return an error. Only once we have determined that we have the right
+     * type are we allowed to advance!
+     */
+    json = _json_iter->peek();
+    if (*json != start_char) { return incorrect_type_error(incorrect_type_message); }
+    _json_iter->return_current_and_advance();
   }
 
-  // Get the JSON and advance the cursor, decreasing depth to signify that we have retrieved the value.
-  assert_at_start();
-  json = _json_iter->advance();
+
   return SUCCESS;
 }
-simdjson_really_inline const uint8_t *value_iterator::advance_root_scalar(const char *type) const noexcept {
-  logger::log_value(*_json_iter, _start_position, depth(), type);
+
+
+simdjson_really_inline const uint8_t *value_iterator::peek_root_scalar(const char *type) noexcept {
+  logger::log_value(*_json_iter, start_position(), depth(), type);
   if (!is_at_start()) { return peek_start(); }
 
   assert_at_root();
-  auto result = _json_iter->advance();
-  _json_iter->ascend_to(depth()-1);
-  return result;
+  return _json_iter->peek();
 }
-simdjson_really_inline const uint8_t *value_iterator::advance_non_root_scalar(const char *type) const noexcept {
-  logger::log_value(*_json_iter, _start_position, depth(), type);
+simdjson_really_inline const uint8_t *value_iterator::peek_non_root_scalar(const char *type) noexcept {
+  logger::log_value(*_json_iter, start_position(), depth(), type);
   if (!is_at_start()) { return peek_start(); }
 
   assert_at_non_root_start();
-  auto result = _json_iter->advance();
+  return _json_iter->peek();
+}
+
+simdjson_really_inline void value_iterator::advance_root_scalar(const char *type) noexcept {
+  logger::log_value(*_json_iter, start_position(), depth(), type);
+  if (!is_at_start()) { return; }
+
+  assert_at_root();
+  _json_iter->return_current_and_advance();
   _json_iter->ascend_to(depth()-1);
-  return result;
+}
+simdjson_really_inline void value_iterator::advance_non_root_scalar(const char *type) noexcept {
+  logger::log_value(*_json_iter, start_position(), depth(), type);
+  if (!is_at_start()) { return; }
+
+  assert_at_non_root_start();
+  _json_iter->return_current_and_advance();
+  _json_iter->ascend_to(depth()-1);
 }
 
 simdjson_really_inline error_code value_iterator::incorrect_type_error(const char *message) const noexcept {
-  logger::log_error(*_json_iter, _start_position, depth(), message);
+  logger::log_error(*_json_iter, start_position(), depth(), message);
   return INCORRECT_TYPE;
 }
 
 simdjson_really_inline bool value_iterator::is_at_start() const noexcept {
-  return _json_iter->token.index == _start_position;
+  return position() == start_position();
 }
-simdjson_really_inline bool value_iterator::is_at_container_start() const noexcept {
-  return _json_iter->token.index == _start_position + 1;
+
+simdjson_really_inline bool value_iterator::is_at_key() const noexcept {
+  // Keys are at the same depth as the object.
+  // Note here that we could be safer and check that we are within an object,
+  // but we do not.
+  return _depth == _json_iter->_depth && *_json_iter->peek() == '"';
 }
+
 simdjson_really_inline bool value_iterator::is_at_iterator_start() const noexcept {
   // We can legitimately be either at the first value ([1]), or after the array if it's empty ([]).
-  auto delta = _json_iter->token.index - _start_position;
+  auto delta = position() - start_position();
   return delta == 1 || delta == 2;
 }
 
-simdjson_really_inline void value_iterator::assert_at_start() const noexcept {
-  SIMDJSON_ASSUME( _json_iter->token.index == _start_position );
+inline void value_iterator::assert_at_start() const noexcept {
+  SIMDJSON_ASSUME( _json_iter->token._position == _start_position );
   SIMDJSON_ASSUME( _json_iter->_depth == _depth );
   SIMDJSON_ASSUME( _depth > 0 );
 }
 
-simdjson_really_inline void value_iterator::assert_at_container_start() const noexcept {
-  SIMDJSON_ASSUME( _json_iter->token.index == _start_position + 1 );
+inline void value_iterator::assert_at_container_start() const noexcept {
+  SIMDJSON_ASSUME( _json_iter->token._position == _start_position + 1 );
   SIMDJSON_ASSUME( _json_iter->_depth == _depth );
   SIMDJSON_ASSUME( _depth > 0 );
 }
 
-simdjson_really_inline void value_iterator::assert_at_next() const noexcept {
-  SIMDJSON_ASSUME( _json_iter->token.index > _start_position );
+inline void value_iterator::assert_at_next() const noexcept {
+  SIMDJSON_ASSUME( _json_iter->token._position > _start_position );
   SIMDJSON_ASSUME( _json_iter->_depth == _depth );
   SIMDJSON_ASSUME( _depth > 0 );
 }
 
-simdjson_really_inline void value_iterator::assert_at_child() const noexcept {
-  SIMDJSON_ASSUME( _json_iter->token.index > _start_position );
+simdjson_really_inline void value_iterator::move_at_start() noexcept {
+  _json_iter->_depth = _depth;
+  _json_iter->token.set_position(_start_position);
+}
+
+simdjson_really_inline void value_iterator::move_at_container_start() noexcept {
+  _json_iter->_depth = _depth;
+  _json_iter->token.set_position(_start_position + 1);
+}
+
+simdjson_really_inline simdjson_result<bool> value_iterator::reset_array() noexcept {
+  move_at_container_start();
+  return started_array();
+}
+
+simdjson_really_inline simdjson_result<bool> value_iterator::reset_object() noexcept {
+  move_at_container_start();
+  return started_object();
+}
+
+inline void value_iterator::assert_at_child() const noexcept {
+  SIMDJSON_ASSUME( _json_iter->token._position > _start_position );
   SIMDJSON_ASSUME( _json_iter->_depth == _depth + 1 );
   SIMDJSON_ASSUME( _depth > 0 );
 }
 
-simdjson_really_inline void value_iterator::assert_at_root() const noexcept {
+inline void value_iterator::assert_at_root() const noexcept {
   assert_at_start();
   SIMDJSON_ASSUME( _depth == 1 );
 }
 
-simdjson_really_inline void value_iterator::assert_at_non_root_start() const noexcept {
+inline void value_iterator::assert_at_non_root_start() const noexcept {
   assert_at_start();
   SIMDJSON_ASSUME( _depth > 1 );
 }
 
-simdjson_really_inline void value_iterator::assert_is_valid() const noexcept {
+inline void value_iterator::assert_is_valid() const noexcept {
   SIMDJSON_ASSUME( _json_iter != nullptr );
 }
 
@@ -22544,8 +25835,7 @@ simdjson_really_inline bool value_iterator::is_valid() const noexcept {
   return _json_iter != nullptr;
 }
 
-
-simdjson_really_inline simdjson_result<json_type> value_iterator::type() noexcept {
+simdjson_really_inline simdjson_result<json_type> value_iterator::type() const noexcept {
   switch (*peek_start()) {
     case '{':
       return json_type::object;
@@ -22564,6 +25854,26 @@ simdjson_really_inline simdjson_result<json_type> value_iterator::type() noexcep
     default:
       return TAPE_ERROR;
   }
+}
+
+simdjson_really_inline token_position value_iterator::start_position() const noexcept {
+  return _start_position;
+}
+
+simdjson_really_inline token_position value_iterator::position() const noexcept {
+  return _json_iter->position();
+}
+
+simdjson_really_inline token_position value_iterator::end_position() const noexcept {
+  return _json_iter->end_position();
+}
+
+simdjson_really_inline token_position value_iterator::last_position() const noexcept {
+  return _json_iter->last_position();
+}
+
+simdjson_really_inline error_code value_iterator::report_error(error_code error, const char *message) noexcept {
+  return _json_iter->report_error(error, message);
 }
 
 } // namespace ondemand
@@ -22602,9 +25912,9 @@ simdjson_really_inline array_iterator &array_iterator::operator++() noexcept {
   error_code error;
   // PERF NOTE this is a safety rail ... users should exit loops as soon as they receive an error, so we'll never get here.
   // However, it does not seem to make a perf difference, so we add it out of an abundance of caution.
-  if ((error = iter.error()) ) { return *this; }
-  if ((error = iter.skip_child() )) { return *this; }
-  if ((error = iter.has_next_element().error() )) { return *this; }
+  if (( error = iter.error() )) { return *this; }
+  if (( error = iter.skip_child() )) { return *this; }
+  if (( error = iter.has_next_element().error() )) { return *this; }
   return *this;
 }
 
@@ -22832,8 +26142,9 @@ simdjson_really_inline simdjson_result<array> array::start_root(value_iterator &
   SIMDJSON_TRY( iter.start_root_array().get(has_value) );
   return array(iter);
 }
-simdjson_really_inline array array::started(value_iterator &iter) noexcept {
-  simdjson_unused bool has_value = iter.started_array();
+simdjson_really_inline simdjson_result<array> array::started(value_iterator &iter) noexcept {
+  bool has_value;
+  SIMDJSON_TRY(iter.started_array().get(has_value));
   return array(iter);
 }
 
@@ -22845,6 +26156,79 @@ simdjson_really_inline simdjson_result<array_iterator> array::begin() noexcept {
 }
 simdjson_really_inline simdjson_result<array_iterator> array::end() noexcept {
   return array_iterator(iter);
+}
+simdjson_really_inline error_code array::consume() noexcept {
+  auto error = iter.json_iter().skip_child(iter.depth()-1);
+  if(error) { iter.abandon(); }
+  return error;
+}
+
+simdjson_really_inline simdjson_result<std::string_view> array::raw_json() noexcept {
+  const uint8_t * starting_point{iter.peek_start()};
+  auto error = consume();
+  if(error) { return error; }
+  // After 'consume()', we could be left pointing just beyond the document, but that
+  // is ok because we are not going to dereference the final pointer position, we just
+  // use it to compute the length in bytes.
+  const uint8_t * final_point{iter._json_iter->unsafe_pointer()};
+  return std::string_view(reinterpret_cast<const char*>(starting_point), size_t(final_point - starting_point));
+}
+
+simdjson_really_inline simdjson_result<size_t> array::count_elements() & noexcept {
+  size_t count{0};
+  // Important: we do not consume any of the values.
+  for(simdjson_unused auto v : *this) { count++; }
+  // The above loop will always succeed, but we want to report errors.
+  if(iter.error()) { return iter.error(); }
+  // We need to move back at the start because we expect users to iterate through
+  // the array after counting the number of elements.
+  iter.reset_array();
+  return count;
+}
+
+inline simdjson_result<value> array::at_pointer(std::string_view json_pointer) noexcept {
+  if (json_pointer[0] != '/') { return INVALID_JSON_POINTER; }
+  json_pointer = json_pointer.substr(1);
+  // - means "the append position" or "the element after the end of the array"
+  // We don't support this, because we're returning a real element, not a position.
+  if (json_pointer == "-") { return INDEX_OUT_OF_BOUNDS; }
+
+  // Read the array index
+  size_t array_index = 0;
+  size_t i;
+  for (i = 0; i < json_pointer.length() && json_pointer[i] != '/'; i++) {
+    uint8_t digit = uint8_t(json_pointer[i] - '0');
+    // Check for non-digit in array index. If it's there, we're trying to get a field in an object
+    if (digit > 9) { return INCORRECT_TYPE; }
+    array_index = array_index*10 + digit;
+  }
+
+  // 0 followed by other digits is invalid
+  if (i > 1 && json_pointer[0] == '0') { return INVALID_JSON_POINTER; } // "JSON pointer array index has other characters after 0"
+
+  // Empty string is invalid; so is a "/" with no digits before it
+  if (i == 0) { return INVALID_JSON_POINTER; } // "Empty string in JSON pointer array index"
+  // Get the child
+  auto child = at(array_index);
+  // If there is an error, it ends here
+  if(child.error()) {
+    return child;
+  }
+
+  // If there is a /, we're not done yet, call recursively.
+  if (i < json_pointer.length()) {
+    child = child.at_pointer(json_pointer.substr(i));
+  }
+  return child;
+}
+
+simdjson_really_inline simdjson_result<value> array::at(size_t index) noexcept {
+  size_t i = 0;
+  for (auto value : *this) {
+    if (i == index) { return value; }
+    i++;
+  }
+  return INDEX_OUT_OF_BOUNDS;
 }
 
 } // namespace ondemand
@@ -22876,7 +26260,18 @@ simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand
   if (error()) { return error(); }
   return first.end();
 }
-
+simdjson_really_inline  simdjson_result<size_t> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array>::count_elements() & noexcept {
+  if (error()) { return error(); }
+  return first.count_elements();
+}
+simdjson_really_inline  simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array>::at(size_t index) noexcept {
+  if (error()) { return error(); }
+  return first.at(index);
+}
+simdjson_really_inline  simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array>::at_pointer(std::string_view json_pointer) noexcept {
+  if (error()) { return error(); }
+  return first.at_pointer(json_pointer);
+}
 } // namespace simdjson
 /* end file include/simdjson/generic/ondemand/array-inl.h */
 /* begin file include/simdjson/generic/ondemand/document-inl.h */
@@ -22894,14 +26289,46 @@ simdjson_really_inline document document::start(json_iterator &&iter) noexcept {
   return document(std::forward<json_iterator>(iter));
 }
 
+inline void document::rewind() noexcept {
+  iter.rewind();
+}
+
+inline std::string document::to_debug_string() noexcept {
+  return iter.to_string();
+}
+
 simdjson_really_inline value_iterator document::resume_value_iterator() noexcept {
-  return value_iterator(&iter, 1, iter.root_checkpoint());
+  return value_iterator(&iter, 1, iter.root_position());
 }
 simdjson_really_inline value_iterator document::get_root_value_iterator() noexcept {
   return resume_value_iterator();
 }
-simdjson_really_inline value document::resume_value() noexcept {
-  return resume_value_iterator();
+simdjson_really_inline simdjson_result<object> document::start_or_resume_object() noexcept {
+  if (iter.at_root()) {
+    return get_object();
+  } else {
+    return object::resume(resume_value_iterator());
+  }
+}
+simdjson_really_inline simdjson_result<value> document::get_value_unsafe() noexcept {
+  // Make sure we start any arrays or objects before returning, so that start_root_<object/array>()
+  // gets called.
+  switch (*iter.peek()) {
+    case '[': {
+      array result;
+      SIMDJSON_TRY( get_array().get(result) );
+      return value(result.iter);
+    }
+    case '{': {
+      object result;
+      SIMDJSON_TRY( get_object().get(result) );
+      return value(result.iter);
+    }
+    default:
+      // TODO it is still wrong to convert this to a value! get_root_bool / etc. will not be
+      // called if you do this.
+      return value(get_root_value_iterator());
+  }
 }
 simdjson_really_inline simdjson_result<array> document::get_array() & noexcept {
   auto value = get_root_value_iterator();
@@ -22914,11 +26341,20 @@ simdjson_really_inline simdjson_result<object> document::get_object() & noexcept
 simdjson_really_inline simdjson_result<uint64_t> document::get_uint64() noexcept {
   return get_root_value_iterator().get_root_uint64();
 }
+simdjson_really_inline simdjson_result<uint64_t> document::get_uint64_in_string() noexcept {
+  return get_root_value_iterator().get_root_uint64_in_string();
+}
 simdjson_really_inline simdjson_result<int64_t> document::get_int64() noexcept {
   return get_root_value_iterator().get_root_int64();
 }
+simdjson_really_inline simdjson_result<int64_t> document::get_int64_in_string() noexcept {
+  return get_root_value_iterator().get_root_int64_in_string();
+}
 simdjson_really_inline simdjson_result<double> document::get_double() noexcept {
   return get_root_value_iterator().get_root_double();
+}
+simdjson_really_inline simdjson_result<double> document::get_double_in_string() noexcept {
+  return get_root_value_iterator().get_root_double_in_string();
 }
 simdjson_really_inline simdjson_result<std::string_view> document::get_string() noexcept {
   return get_root_value_iterator().get_root_string();
@@ -22966,7 +26402,13 @@ simdjson_really_inline document::operator std::string_view() noexcept(false) { r
 simdjson_really_inline document::operator raw_json_string() noexcept(false) { return get_raw_json_string(); }
 simdjson_really_inline document::operator bool() noexcept(false) { return get_bool(); }
 #endif
-
+simdjson_really_inline simdjson_result<size_t> document::count_elements() & noexcept {
+  auto a = get_array();
+  simdjson_result<size_t> answer = a.count_elements();
+  /* If there was an array, we are now left pointing at its first element. */
+  if(answer.error() == SUCCESS) { iter._depth -= 1 ; /* undoing the increment so we go back at the doc depth.*/ }
+  return answer;
+}
 simdjson_really_inline simdjson_result<array_iterator> document::begin() & noexcept {
   return get_array().begin();
 }
@@ -22975,22 +26417,40 @@ simdjson_really_inline simdjson_result<array_iterator> document::end() & noexcep
 }
 
 simdjson_really_inline simdjson_result<value> document::find_field(std::string_view key) & noexcept {
-  return resume_value().find_field(key);
+  return start_or_resume_object().find_field(key);
 }
 simdjson_really_inline simdjson_result<value> document::find_field(const char *key) & noexcept {
-  return resume_value().find_field(key);
+  return start_or_resume_object().find_field(key);
 }
 simdjson_really_inline simdjson_result<value> document::find_field_unordered(std::string_view key) & noexcept {
-  return resume_value().find_field_unordered(key);
+  return start_or_resume_object().find_field_unordered(key);
 }
 simdjson_really_inline simdjson_result<value> document::find_field_unordered(const char *key) & noexcept {
-  return resume_value().find_field_unordered(key);
+  return start_or_resume_object().find_field_unordered(key);
 }
 simdjson_really_inline simdjson_result<value> document::operator[](std::string_view key) & noexcept {
-  return resume_value()[key];
+  return start_or_resume_object()[key];
 }
 simdjson_really_inline simdjson_result<value> document::operator[](const char *key) & noexcept {
-  return resume_value()[key];
+  return start_or_resume_object()[key];
+}
+
+simdjson_really_inline error_code document::consume() noexcept {
+  auto error = iter.skip_child(0);
+  if(error) { iter.abandon(); }
+  return error;
+}
+
+simdjson_really_inline simdjson_result<std::string_view> document::raw_json() noexcept {
+  auto _iter = get_root_value_iterator();
+  const uint8_t * starting_point{_iter.peek_start()};
+  auto error = consume();
+  if(error) { return error; }
+  // After 'consume()', we could be left pointing just beyond the document, but that
+  // is ok because we are not going to dereference the final pointer position, we just
+  // use it to compute the length in bytes.
+  const uint8_t * final_point{iter.unsafe_pointer()};
+  return std::string_view(reinterpret_cast<const char*>(starting_point), size_t(final_point - starting_point));
 }
 
 simdjson_really_inline simdjson_result<json_type> document::type() noexcept {
@@ -23000,6 +26460,24 @@ simdjson_really_inline simdjson_result<json_type> document::type() noexcept {
 simdjson_really_inline simdjson_result<std::string_view> document::raw_json_token() noexcept {
   auto _iter = get_root_value_iterator();
   return std::string_view(reinterpret_cast<const char*>(_iter.peek_start()), _iter.peek_start_length());
+}
+
+simdjson_really_inline simdjson_result<value> document::at_pointer(std::string_view json_pointer) noexcept {
+  rewind(); // Rewind the document each time at_pointer is called
+  if (json_pointer.empty()) {
+    return this->get_value_unsafe();
+  }
+  json_type t;
+  SIMDJSON_TRY(type().get(t));
+  switch (t)
+  {
+    case json_type::array:
+      return (*this).get_array().at_pointer(json_pointer);
+    case json_type::object:
+      return (*this).get_object().at_pointer(json_pointer);
+    default:
+      return INVALID_JSON_POINTER;
+  }
 }
 
 } // namespace ondemand
@@ -23024,7 +26502,15 @@ simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand
     )
 {
 }
-
+simdjson_really_inline simdjson_result<size_t> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document>::count_elements() & noexcept {
+  if (error()) { return error(); }
+  return first.count_elements();
+}
+simdjson_really_inline error_code simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document>::rewind() noexcept {
+  if (error()) { return error(); }
+  first.rewind();
+  return SUCCESS;
+}
 simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document>::begin() & noexcept {
   if (error()) { return error(); }
   return first.begin();
@@ -23171,6 +26657,196 @@ simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSO
   return first.raw_json_token();
 }
 
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document>::at_pointer(std::string_view json_pointer) noexcept {
+  if (error()) { return error(); }
+  return first.at_pointer(json_pointer);
+}
+
+
+} // namespace simdjson
+
+
+namespace simdjson {
+namespace SIMDJSON_BUILTIN_IMPLEMENTATION {
+namespace ondemand {
+
+simdjson_really_inline document_reference::document_reference() noexcept : doc{nullptr} {}
+simdjson_really_inline document_reference::document_reference(document &d) noexcept : doc(&d) {}
+simdjson_really_inline void document_reference::rewind() noexcept { doc->rewind(); }
+simdjson_really_inline simdjson_result<array> document_reference::get_array() & noexcept { return doc->get_array(); }
+simdjson_really_inline simdjson_result<object> document_reference::get_object() & noexcept { return doc->get_object(); }
+simdjson_really_inline simdjson_result<uint64_t> document_reference::get_uint64() noexcept { return doc->get_uint64(); }
+simdjson_really_inline simdjson_result<int64_t> document_reference::get_int64() noexcept { return doc->get_int64(); }
+simdjson_really_inline simdjson_result<double> document_reference::get_double() noexcept { return doc->get_double(); }
+simdjson_really_inline simdjson_result<std::string_view> document_reference::get_string() noexcept { return doc->get_string(); }
+simdjson_really_inline simdjson_result<raw_json_string> document_reference::get_raw_json_string() noexcept { return doc->get_raw_json_string(); }
+simdjson_really_inline simdjson_result<bool> document_reference::get_bool() noexcept { return doc->get_bool(); }
+simdjson_really_inline bool document_reference::is_null() noexcept { return doc->is_null(); }
+
+#if SIMDJSON_EXCEPTIONS
+simdjson_really_inline document_reference::operator array() & noexcept(false) { return array(*doc); }
+simdjson_really_inline document_reference::operator object() & noexcept(false) { return object(*doc); }
+simdjson_really_inline document_reference::operator uint64_t() noexcept(false) { return uint64_t(*doc); }
+simdjson_really_inline document_reference::operator int64_t() noexcept(false) { return int64_t(*doc); }
+simdjson_really_inline document_reference::operator double() noexcept(false) { return double(*doc); }
+simdjson_really_inline document_reference::operator std::string_view() noexcept(false) { return std::string_view(*doc); }
+simdjson_really_inline document_reference::operator raw_json_string() noexcept(false) { return raw_json_string(*doc); }
+simdjson_really_inline document_reference::operator bool() noexcept(false) { return bool(*doc); }
+#endif
+simdjson_really_inline simdjson_result<size_t> document_reference::count_elements() & noexcept { return doc->count_elements(); }
+simdjson_really_inline simdjson_result<array_iterator> document_reference::begin() & noexcept { return doc->begin(); }
+simdjson_really_inline simdjson_result<array_iterator> document_reference::end() & noexcept { return doc->end(); }
+simdjson_really_inline simdjson_result<value> document_reference::find_field(std::string_view key) & noexcept { return doc->find_field(key); }
+simdjson_really_inline simdjson_result<value> document_reference::find_field(const char *key) & noexcept { return doc->find_field(key); }
+simdjson_really_inline simdjson_result<value> document_reference::operator[](std::string_view key) & noexcept { return (*doc)[key]; }
+simdjson_really_inline simdjson_result<value> document_reference::operator[](const char *key) & noexcept { return (*doc)[key]; }
+simdjson_really_inline simdjson_result<value> document_reference::find_field_unordered(std::string_view key) & noexcept { return doc->find_field_unordered(key); }
+simdjson_really_inline simdjson_result<value> document_reference::find_field_unordered(const char *key) & noexcept { return doc->find_field_unordered(key); }
+
+simdjson_really_inline simdjson_result<json_type> document_reference::type() noexcept { return doc->type(); }
+simdjson_really_inline simdjson_result<std::string_view> document_reference::raw_json_token() noexcept { return doc->raw_json_token(); }
+simdjson_really_inline simdjson_result<value> document_reference::at_pointer(std::string_view json_pointer) noexcept { return doc->at_pointer(json_pointer); }
+simdjson_really_inline simdjson_result<std::string_view> document_reference::raw_json() noexcept { return doc->raw_json();}
+simdjson_really_inline document_reference::operator document&() const noexcept { return *doc; }
+
+} // namespace ondemand
+} // namespace SIMDJSON_BUILTIN_IMPLEMENTATION
+} // namespace simdjson
+
+
+
+namespace simdjson {
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::simdjson_result(SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference value, error_code error)
+  noexcept : implementation_simdjson_result_base<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>(std::forward<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>(value), error) {}
+
+
+simdjson_really_inline simdjson_result<size_t> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::count_elements() & noexcept {
+  if (error()) { return error(); }
+  return first.count_elements();
+}
+simdjson_really_inline error_code simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::rewind() noexcept {
+  if (error()) { return error(); }
+  first.rewind();
+  return SUCCESS;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::begin() & noexcept {
+  if (error()) { return error(); }
+  return first.begin();
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::end() & noexcept {
+  return {};
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::find_field_unordered(std::string_view key) & noexcept {
+  if (error()) { return error(); }
+  return first.find_field_unordered(key);
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::find_field_unordered(const char *key) & noexcept {
+  if (error()) { return error(); }
+  return first.find_field_unordered(key);
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::operator[](std::string_view key) & noexcept {
+  if (error()) { return error(); }
+  return first[key];
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::operator[](const char *key) & noexcept {
+  if (error()) { return error(); }
+  return first[key];
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::find_field(std::string_view key) & noexcept {
+  if (error()) { return error(); }
+  return first.find_field(key);
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::find_field(const char *key) & noexcept {
+  if (error()) { return error(); }
+  return first.find_field(key);
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::get_array() & noexcept {
+  if (error()) { return error(); }
+  return first.get_array();
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::get_object() & noexcept {
+  if (error()) { return error(); }
+  return first.get_object();
+}
+simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::get_uint64() noexcept {
+  if (error()) { return error(); }
+  return first.get_uint64();
+}
+simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::get_int64() noexcept {
+  if (error()) { return error(); }
+  return first.get_int64();
+}
+simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::get_double() noexcept {
+  if (error()) { return error(); }
+  return first.get_double();
+}
+simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::get_string() noexcept {
+  if (error()) { return error(); }
+  return first.get_string();
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::get_raw_json_string() noexcept {
+  if (error()) { return error(); }
+  return first.get_raw_json_string();
+}
+simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::get_bool() noexcept {
+  if (error()) { return error(); }
+  return first.get_bool();
+}
+simdjson_really_inline bool simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::is_null() noexcept {
+  if (error()) { return error(); }
+  return first.is_null();
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::json_type> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::type() noexcept {
+  if (error()) { return error(); }
+  return first.type();
+}
+
+#if SIMDJSON_EXCEPTIONS
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array() & noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object() & noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::operator uint64_t() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::operator int64_t() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::operator double() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::operator std::string_view() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::operator bool() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+#endif
+
+simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::raw_json_token() noexcept {
+  if (error()) { return error(); }
+  return first.raw_json_token();
+}
+
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>::at_pointer(std::string_view json_pointer) noexcept {
+  if (error()) { return error(); }
+  return first.at_pointer(json_pointer);
+}
+
+
 } // namespace simdjson
 /* end file include/simdjson/generic/ondemand/document-inl.h */
 /* begin file include/simdjson/generic/ondemand/value-inl.h */
@@ -23212,11 +26888,20 @@ simdjson_really_inline simdjson_result<std::string_view> value::get_string() noe
 simdjson_really_inline simdjson_result<double> value::get_double() noexcept {
   return iter.get_double();
 }
+simdjson_really_inline simdjson_result<double> value::get_double_in_string() noexcept {
+  return iter.get_double_in_string();
+}
 simdjson_really_inline simdjson_result<uint64_t> value::get_uint64() noexcept {
   return iter.get_uint64();
 }
+simdjson_really_inline simdjson_result<uint64_t> value::get_uint64_in_string() noexcept {
+  return iter.get_uint64_in_string();
+}
 simdjson_really_inline simdjson_result<int64_t> value::get_int64() noexcept {
   return iter.get_int64();
+}
+simdjson_really_inline simdjson_result<int64_t> value::get_int64_in_string() noexcept {
+  return iter.get_int64_in_string();
 }
 simdjson_really_inline simdjson_result<bool> value::get_bool() noexcept {
   return iter.get_bool();
@@ -23271,6 +26956,16 @@ simdjson_really_inline simdjson_result<array_iterator> value::begin() & noexcept
 simdjson_really_inline simdjson_result<array_iterator> value::end() & noexcept {
   return {};
 }
+simdjson_really_inline simdjson_result<size_t> value::count_elements() & noexcept {
+  simdjson_result<size_t> answer;
+  auto a = get_array();
+  answer = a.count_elements();
+  // count_elements leaves you pointing inside the array, at the first element.
+  // We need to move back so that the user can create a new array (which requires that
+  // we point at '[').
+  iter.move_at_start();
+  return answer;
+}
 
 simdjson_really_inline simdjson_result<value> value::find_field(std::string_view key) noexcept {
   return start_or_resume_object().find_field(key);
@@ -23301,6 +26996,20 @@ simdjson_really_inline std::string_view value::raw_json_token() noexcept {
   return std::string_view(reinterpret_cast<const char*>(iter.peek_start()), iter.peek_start_length());
 }
 
+simdjson_really_inline simdjson_result<value> value::at_pointer(std::string_view json_pointer) noexcept {
+  json_type t;
+  SIMDJSON_TRY(type().get(t));
+  switch (t)
+  {
+    case json_type::array:
+      return (*this).get_array().at_pointer(json_pointer);
+    case json_type::object:
+      return (*this).get_object().at_pointer(json_pointer);
+    default:
+      return INVALID_JSON_POINTER;
+  }
+}
+
 } // namespace ondemand
 } // namespace SIMDJSON_BUILTIN_IMPLEMENTATION
 } // namespace simdjson
@@ -23321,7 +27030,10 @@ simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand
     implementation_simdjson_result_base<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value>(error)
 {
 }
-
+simdjson_really_inline simdjson_result<size_t> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value>::count_elements() & noexcept {
+  if (error()) { return error(); }
+  return first.count_elements();
+}
 simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value>::begin() & noexcept {
   if (error()) { return error(); }
   return first.begin();
@@ -23370,13 +27082,25 @@ simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_BUILTI
   if (error()) { return error(); }
   return first.get_uint64();
 }
+simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value>::get_uint64_in_string() noexcept {
+  if (error()) { return error(); }
+  return first.get_uint64_in_string();
+}
 simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value>::get_int64() noexcept {
   if (error()) { return error(); }
   return first.get_int64();
 }
+simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value>::get_int64_in_string() noexcept {
+  if (error()) { return error(); }
+  return first.get_int64_in_string();
+}
 simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value>::get_double() noexcept {
   if (error()) { return error(); }
   return first.get_double();
+}
+simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value>::get_double_in_string() noexcept {
+  if (error()) { return error(); }
+  return first.get_double_in_string();
 }
 simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value>::get_string() noexcept {
   if (error()) { return error(); }
@@ -23459,6 +27183,11 @@ simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSO
   return first.raw_json_token();
 }
 
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value>::at_pointer(std::string_view json_pointer) noexcept {
+  if (error()) { return error(); }
+  return first.at_pointer(json_pointer);
+}
+
 } // namespace simdjson
 /* end file include/simdjson/generic/ondemand/value-inl.h */
 /* begin file include/simdjson/generic/ondemand/field-inl.h */
@@ -23486,7 +27215,7 @@ simdjson_really_inline simdjson_result<field> field::start(const value_iterator 
 }
 
 simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> field::unescaped_key() noexcept {
-  SIMDJSON_ASSUME(first.buf != nullptr); // We would like to call .alive() by Visual Studio won't let us.
+  SIMDJSON_ASSUME(first.buf != nullptr); // We would like to call .alive() but Visual Studio won't let us.
   simdjson_result<std::string_view> answer = first.unescape(second.iter.string_buf_loc());
   first.consume();
   return answer;
@@ -23578,21 +27307,52 @@ simdjson_really_inline simdjson_result<value> object::find_field(const std::stri
 }
 
 simdjson_really_inline simdjson_result<object> object::start(value_iterator &iter) noexcept {
-  // We don't need to know if the object is empty to start iteration, but we do want to know if there
-  // is an error--thus `simdjson_unused`.
-  simdjson_unused bool has_value;
-  SIMDJSON_TRY( iter.start_object().get(has_value) );
+  SIMDJSON_TRY( iter.start_object().error() );
   return object(iter);
 }
 simdjson_really_inline simdjson_result<object> object::start_root(value_iterator &iter) noexcept {
-  simdjson_unused bool has_value;
-  SIMDJSON_TRY( iter.start_root_object().get(has_value) );
+  SIMDJSON_TRY( iter.start_root_object().error() );
   return object(iter);
 }
-simdjson_really_inline object object::started(value_iterator &iter) noexcept {
-  simdjson_unused bool has_value = iter.started_object();
-  return iter;
+simdjson_really_inline error_code object::consume() noexcept {
+  if(iter.is_at_key()) {
+    /**
+     * whenever you are pointing at a key, calling skip_child() is
+     * unsafe because you will hit a string and you will assume that
+     * it is string value, and this mistake will lead you to make bad
+     * depth computation.
+     */
+    /**
+     * We want to 'consume' the key. We could really
+     * just do _json_iter->return_current_and_advance(); at this
+     * point, but, for clarity, we will use the high-level API to
+     * eat the key. We assume that the compiler optimizes away
+     * most of the work.
+     */
+    simdjson_unused raw_json_string actual_key;
+    auto error = iter.field_key().get(actual_key);
+    if (error) { iter.abandon(); return error; };
+    // Let us move to the value while we are at it.
+    if ((error = iter.field_value())) { iter.abandon(); return error; }
+  }
+  auto error_skip = iter.json_iter().skip_child(iter.depth()-1);
+  if(error_skip) { iter.abandon(); }
+  return error_skip;
 }
+
+simdjson_really_inline simdjson_result<std::string_view> object::raw_json() noexcept {
+  const uint8_t * starting_point{iter.peek_start()};
+  auto error = consume();
+  if(error) { return error; }
+  const uint8_t * final_point{iter._json_iter->peek(0)};
+  return std::string_view(reinterpret_cast<const char*>(starting_point), size_t(final_point - starting_point));
+}
+
+simdjson_really_inline simdjson_result<object> object::started(value_iterator &iter) noexcept {
+  SIMDJSON_TRY( iter.started_object().error() );
+  return object(iter);
+}
+
 simdjson_really_inline object object::resume(const value_iterator &iter) noexcept {
   return iter;
 }
@@ -23610,6 +27370,46 @@ simdjson_really_inline simdjson_result<object_iterator> object::begin() noexcept
 }
 simdjson_really_inline simdjson_result<object_iterator> object::end() noexcept {
   return object_iterator(iter);
+}
+
+inline simdjson_result<value> object::at_pointer(std::string_view json_pointer) noexcept {
+  if (json_pointer[0] != '/') { return INVALID_JSON_POINTER; }
+  json_pointer = json_pointer.substr(1);
+  size_t slash = json_pointer.find('/');
+  std::string_view key = json_pointer.substr(0, slash);
+  // Grab the child with the given key
+  simdjson_result<value> child;
+
+  // If there is an escape character in the key, unescape it and then get the child.
+  size_t escape = key.find('~');
+  if (escape != std::string_view::npos) {
+    // Unescape the key
+    std::string unescaped(key);
+    do {
+      switch (unescaped[escape+1]) {
+        case '0':
+          unescaped.replace(escape, 2, "~");
+          break;
+        case '1':
+          unescaped.replace(escape, 2, "/");
+          break;
+        default:
+          return INVALID_JSON_POINTER; // "Unexpected ~ escape character in JSON pointer");
+      }
+      escape = unescaped.find('~', escape+1);
+    } while (escape != std::string::npos);
+    child = find_field(unescaped);  // Take note find_field does not unescape keys when matching
+  } else {
+    child = find_field(key);
+  }
+  if(child.error()) {
+    return child; // we do not continue if there was an error
+  }
+  // If there is a /, we have to recurse and look up more of the path
+  if (slash != std::string_view::npos) {
+    child = child.at_pointer(json_pointer.substr(slash));
+  }
+  return child;
 }
 
 } // namespace ondemand
@@ -23656,6 +27456,11 @@ simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand
   return std::forward<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object>(first).find_field(key);
 }
 
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object>::at_pointer(std::string_view json_pointer) noexcept {
+  if (error()) { return error(); }
+  return first.at_pointer(json_pointer);
+}
+
 } // namespace simdjson
 /* end file include/simdjson/generic/ondemand/object-inl.h */
 /* begin file include/simdjson/generic/ondemand/parser-inl.h */
@@ -23663,7 +27468,12 @@ namespace simdjson {
 namespace SIMDJSON_BUILTIN_IMPLEMENTATION {
 namespace ondemand {
 
+simdjson_really_inline parser::parser(size_t max_capacity) noexcept
+  : _max_capacity{max_capacity} {
+}
+
 simdjson_warn_unused simdjson_really_inline error_code parser::allocate(size_t new_capacity, size_t new_max_depth) noexcept {
+  if (new_capacity > max_capacity()) { return CAPACITY; }
   if (string_buf && new_capacity == capacity() && new_max_depth == max_depth()) { return SUCCESS; }
 
   // string_capacity copied from document::allocate
@@ -23693,7 +27503,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<document> parser::it
   }
 
   // Run stage 1.
-  SIMDJSON_TRY( implementation->stage1(reinterpret_cast<const uint8_t *>(json.data()), json.length(), false) );
+  SIMDJSON_TRY( implementation->stage1(reinterpret_cast<const uint8_t *>(json.data()), json.length(), stage1_mode::regular) );
   return document::start({ reinterpret_cast<const uint8_t *>(json.data()), this });
 }
 
@@ -23736,17 +27546,42 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<json_iterator> parse
   }
 
   // Run stage 1.
-  SIMDJSON_TRY( implementation->stage1(reinterpret_cast<const uint8_t *>(json.data()), json.length(), false) );
+  SIMDJSON_TRY( implementation->stage1(reinterpret_cast<const uint8_t *>(json.data()), json.length(), stage1_mode::regular) );
   return json_iterator(reinterpret_cast<const uint8_t *>(json.data()), this);
+}
+
+inline simdjson_result<document_stream> parser::iterate_many(const uint8_t *buf, size_t len, size_t batch_size) noexcept {
+  if(batch_size < MINIMAL_BATCH_SIZE) { batch_size = MINIMAL_BATCH_SIZE; }
+  return document_stream(*this, buf, len, batch_size);
+}
+inline simdjson_result<document_stream> parser::iterate_many(const char *buf, size_t len, size_t batch_size) noexcept {
+  return iterate_many(reinterpret_cast<const uint8_t *>(buf), len, batch_size);
+}
+inline simdjson_result<document_stream> parser::iterate_many(const std::string &s, size_t batch_size) noexcept {
+  return iterate_many(s.data(), s.length(), batch_size);
+}
+inline simdjson_result<document_stream> parser::iterate_many(const padded_string &s, size_t batch_size) noexcept {
+  return iterate_many(s.data(), s.length(), batch_size);
 }
 
 simdjson_really_inline size_t parser::capacity() const noexcept {
   return _capacity;
 }
+simdjson_really_inline size_t parser::max_capacity() const noexcept {
+  return _max_capacity;
+}
 simdjson_really_inline size_t parser::max_depth() const noexcept {
   return _max_depth;
 }
 
+simdjson_really_inline void parser::set_max_capacity(size_t max_capacity) noexcept {
+  size_t MINIMAL_DOCUMENT_CAPACITY = 32;
+  if(max_capacity < MINIMAL_DOCUMENT_CAPACITY) {
+    _max_capacity = max_capacity;
+  } else {
+    _max_capacity = MINIMAL_DOCUMENT_CAPACITY;
+  }
+}
 
 } // namespace ondemand
 } // namespace SIMDJSON_BUILTIN_IMPLEMENTATION
@@ -23761,6 +27596,634 @@ simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand
 
 } // namespace simdjson
 /* end file include/simdjson/generic/ondemand/parser-inl.h */
+/* begin file include/simdjson/generic/ondemand/document_stream-inl.h */
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+namespace simdjson {
+namespace SIMDJSON_BUILTIN_IMPLEMENTATION {
+namespace ondemand {
+
+#ifdef SIMDJSON_THREADS_ENABLED
+
+inline void stage1_worker::finish() {
+  // After calling "run" someone would call finish() to wait
+  // for the end of the processing.
+  // This function will wait until either the thread has done
+  // the processing or, else, the destructor has been called.
+  std::unique_lock<std::mutex> lock(locking_mutex);
+  cond_var.wait(lock, [this]{return has_work == false;});
+}
+
+inline stage1_worker::~stage1_worker() {
+  // The thread may never outlive the stage1_worker instance
+  // and will always be stopped/joined before the stage1_worker
+  // instance is gone.
+  stop_thread();
+}
+
+inline void stage1_worker::start_thread() {
+  std::unique_lock<std::mutex> lock(locking_mutex);
+  if(thread.joinable()) {
+    return; // This should never happen but we never want to create more than one thread.
+  }
+  thread = std::thread([this]{
+      while(true) {
+        std::unique_lock<std::mutex> thread_lock(locking_mutex);
+        // We wait for either "run" or "stop_thread" to be called.
+        cond_var.wait(thread_lock, [this]{return has_work || !can_work;});
+        // If, for some reason, the stop_thread() method was called (i.e., the
+        // destructor of stage1_worker is called, then we want to immediately destroy
+        // the thread (and not do any more processing).
+        if(!can_work) {
+          break;
+        }
+        this->owner->stage1_thread_error = this->owner->run_stage1(*this->stage1_thread_parser,
+              this->_next_batch_start);
+        this->has_work = false;
+        // The condition variable call should be moved after thread_lock.unlock() for performance
+        // reasons but thread sanitizers may report it as a data race if we do.
+        // See https://stackoverflow.com/questions/35775501/c-should-condition-variable-be-notified-under-lock
+        cond_var.notify_one(); // will notify "finish"
+        thread_lock.unlock();
+      }
+    }
+  );
+}
+
+
+inline void stage1_worker::stop_thread() {
+  std::unique_lock<std::mutex> lock(locking_mutex);
+  // We have to make sure that all locks can be released.
+  can_work = false;
+  has_work = false;
+  cond_var.notify_all();
+  lock.unlock();
+  if(thread.joinable()) {
+    thread.join();
+  }
+}
+
+inline void stage1_worker::run(document_stream * ds, parser * stage1, size_t next_batch_start) {
+  std::unique_lock<std::mutex> lock(locking_mutex);
+  owner = ds;
+  _next_batch_start = next_batch_start;
+  stage1_thread_parser = stage1;
+  has_work = true;
+  // The condition variable call should be moved after thread_lock.unlock() for performance
+  // reasons but thread sanitizers may report it as a data race if we do.
+  // See https://stackoverflow.com/questions/35775501/c-should-condition-variable-be-notified-under-lock
+  cond_var.notify_one(); // will notify the thread lock that we have work
+  lock.unlock();
+}
+
+#endif  // SIMDJSON_THREADS_ENABLED
+
+simdjson_really_inline document_stream::document_stream(
+  ondemand::parser &_parser,
+  const uint8_t *_buf,
+  size_t _len,
+  size_t _batch_size
+) noexcept
+  : parser{&_parser},
+    buf{_buf},
+    len{_len},
+    batch_size{_batch_size <= MINIMAL_BATCH_SIZE ? MINIMAL_BATCH_SIZE : _batch_size},
+    error{SUCCESS}
+    #ifdef SIMDJSON_THREADS_ENABLED
+    , use_thread(_parser.threaded) // we need to make a copy because _parser.threaded can change
+    #endif
+{
+#ifdef SIMDJSON_THREADS_ENABLED
+  if(worker.get() == nullptr) {
+    error = MEMALLOC;
+  }
+#endif
+}
+
+simdjson_really_inline document_stream::document_stream() noexcept
+  : parser{nullptr},
+    buf{nullptr},
+    len{0},
+    batch_size{0},
+    error{UNINITIALIZED}
+    #ifdef SIMDJSON_THREADS_ENABLED
+    , use_thread(false)
+    #endif
+{
+}
+
+simdjson_really_inline document_stream::~document_stream() noexcept
+{
+  #ifdef SIMDJSON_THREADS_ENABLED
+  worker.reset();
+  #endif
+}
+
+inline size_t document_stream::size_in_bytes() const noexcept {
+  return len;
+}
+
+inline size_t document_stream::truncated_bytes() const noexcept {
+  return parser->implementation->structural_indexes[parser->implementation->n_structural_indexes] - parser->implementation->structural_indexes[parser->implementation->n_structural_indexes + 1];
+}
+
+simdjson_really_inline document_stream::iterator::iterator() noexcept
+  : stream{nullptr}, finished{true} {
+}
+
+simdjson_really_inline document_stream::iterator::iterator(document_stream* _stream, bool is_end) noexcept
+  : stream{_stream}, finished{is_end} {
+}
+
+simdjson_really_inline simdjson_result<ondemand::document_reference> document_stream::iterator::operator*() noexcept {
+  //if(stream->error) { return stream->error; }
+  return simdjson_result<ondemand::document_reference>(stream->doc, stream->error);
+}
+
+simdjson_really_inline document_stream::iterator& document_stream::iterator::operator++() noexcept {
+  // If there is an error, then we want the iterator
+  // to be finished, no matter what. (E.g., we do not
+  // keep generating documents with errors, or go beyond
+  // a document with errors.)
+  //
+  // Users do not have to call "operator*()" when they use operator++,
+  // so we need to end the stream in the operator++ function.
+  //
+  // Note that setting finished = true is essential otherwise
+  // we would enter an infinite loop.
+  if (stream->error) { finished = true; }
+  // Note that stream->error() is guarded against error conditions
+  // (it will immediately return if stream->error casts to false).
+  // In effect, this next function does nothing when (stream->error)
+  // is true (hence the risk of an infinite loop).
+  stream->next();
+  // If that was the last document, we're finished.
+  // It is the only type of error we do not want to appear
+  // in operator*.
+  if (stream->error == EMPTY) { finished = true; }
+  // If we had any other kind of error (not EMPTY) then we want
+  // to pass it along to the operator* and we cannot mark the result
+  // as "finished" just yet.
+  return *this;
+}
+
+simdjson_really_inline bool document_stream::iterator::operator!=(const document_stream::iterator &other) const noexcept {
+  return finished != other.finished;
+}
+
+simdjson_really_inline document_stream::iterator document_stream::begin() noexcept {
+  start();
+  // If there are no documents, we're finished.
+  return iterator(this, error == EMPTY);
+}
+
+simdjson_really_inline document_stream::iterator document_stream::end() noexcept {
+  return iterator(this, true);
+}
+
+inline void document_stream::start() noexcept {
+  if (error) { return; }
+  error = parser->allocate(batch_size);
+  if (error) { return; }
+  // Always run the first stage 1 parse immediately
+  batch_start = 0;
+  error = run_stage1(*parser, batch_start);
+  while(error == EMPTY) {
+    // In exceptional cases, we may start with an empty block
+    batch_start = next_batch_start();
+    if (batch_start >= len) { return; }
+    error = run_stage1(*parser, batch_start);
+  }
+  if (error) { return; }
+  doc_index = batch_start;
+  doc = document(json_iterator(&buf[batch_start], parser));
+  doc.iter._streaming = true;
+
+  #ifdef SIMDJSON_THREADS_ENABLED
+  if (use_thread && next_batch_start() < len) {
+    // Kick off the first thread on next batch if needed
+    error = stage1_thread_parser.allocate(batch_size);
+    if (error) { return; }
+    worker->start_thread();
+    start_stage1_thread();
+    if (error) { return; }
+  }
+  #endif // SIMDJSON_THREADS_ENABLED
+}
+
+inline void document_stream::next() noexcept {
+  // We always enter at once once in an error condition.
+  if (error) { return; }
+  next_document();
+  if (error) { return; }
+  auto cur_struct_index = doc.iter._root - parser->implementation->structural_indexes.get();
+  doc_index = batch_start + parser->implementation->structural_indexes[cur_struct_index];
+
+  // Check if at end of structural indexes (i.e. at end of batch)
+  if(cur_struct_index >= static_cast<int64_t>(parser->implementation->n_structural_indexes)) {
+    error = EMPTY;
+    // Load another batch (if available)
+    while (error == EMPTY) {
+      batch_start = next_batch_start();
+      if (batch_start >= len) { break; }
+      #ifdef SIMDJSON_THREADS_ENABLED
+      if(use_thread) {
+        load_from_stage1_thread();
+      } else {
+        error = run_stage1(*parser, batch_start);
+      }
+      #else
+      error = run_stage1(*parser, batch_start);
+      #endif
+      /**
+       * Whenever we move to another window, we need to update all pointers to make
+       * it appear as if the input buffer started at the beginning of the window.
+       *
+       * Take this input:
+       *
+       * {"z":5}  {"1":1,"2":2,"4":4} [7,  10,   9]  [15,  11,   12, 13]  [154,  110,   112, 1311]
+       *
+       * Say you process the following window...
+       *
+       * '{"z":5}  {"1":1,"2":2,"4":4} [7,  10,   9]'
+       *
+       * When you do so, the json_iterator has a pointer at the beginning of the memory region
+       * (pointing at the beginning of '{"z"...'.
+       *
+       * When you move to the window that starts at...
+       *
+       * '[7,  10,   9]  [15,  11,   12, 13] ...
+       *
+       * then it is not sufficient to just run stage 1. You also need to re-anchor the
+       * json_iterator so that it believes we are starting at '[7,  10,   9]...'.
+       *
+       * Under the DOM front-end, this gets done automatically because the parser owns
+       * the pointer the data, and when you call stage1 and then stage2 on the same
+       * parser, then stage2 will run on the pointer acquired by stage1.
+       *
+       * That is, stage1 calls "this->buf = _buf" so the parser remembers the buffer that
+       * we used. But json_iterator has no callback when stage1 is called on the parser.
+       * In fact, I think that the parser is unaware of json_iterator.
+       *
+       *
+       * So we need to re-anchor the json_iterator after each call to stage 1 so that
+       * all of the pointers are in sync.
+       */
+      doc.iter = json_iterator(&buf[batch_start], parser);
+      doc.iter._streaming = true;
+      /**
+       * End of resync.
+       */
+
+      if (error) { continue; } // If the error was EMPTY, we may want to load another batch.
+      doc_index = batch_start;
+    }
+  }
+}
+
+inline void document_stream::next_document() noexcept {
+  // Go to next place where depth=0 (document depth)
+  error = doc.iter.skip_child(0);
+  if (error) { return; }
+  // Always set depth=1 at the start of document
+  doc.iter._depth = 1;
+  // Resets the string buffer at the beginning, thus invalidating the strings.
+  doc.iter._string_buf_loc = parser->string_buf.get();
+  doc.iter._root = doc.iter.position();
+}
+
+inline size_t document_stream::next_batch_start() const noexcept {
+  return batch_start + parser->implementation->structural_indexes[parser->implementation->n_structural_indexes];
+}
+
+inline error_code document_stream::run_stage1(ondemand::parser &p, size_t _batch_start) noexcept {
+  // This code only updates the structural index in the parser, it does not update any json_iterator
+  // instance.
+  size_t remaining = len - _batch_start;
+  if (remaining <= batch_size) {
+    return p.implementation->stage1(&buf[_batch_start], remaining, stage1_mode::streaming_final);
+  } else {
+    return p.implementation->stage1(&buf[_batch_start], batch_size, stage1_mode::streaming_partial);
+  }
+}
+
+simdjson_really_inline size_t document_stream::iterator::current_index() const noexcept {
+  return stream->doc_index;
+}
+
+simdjson_really_inline std::string_view document_stream::iterator::source() const noexcept {
+  auto depth = stream->doc.iter.depth();
+  auto cur_struct_index = stream->doc.iter._root - stream->parser->implementation->structural_indexes.get();
+
+  // If at root, process the first token to determine if scalar value
+  if (stream->doc.iter.at_root()) {
+    switch (stream->buf[stream->batch_start + stream->parser->implementation->structural_indexes[cur_struct_index]]) {
+      case '{': case '[':   // Depth=1 already at start of document
+        break;
+      case '}': case ']':
+        depth--;
+        break;
+      default:    // Scalar value document
+        // TODO: Remove any trailing whitespaces
+        // This returns a string spanning from start of value to the beginning of the next document (excluded)
+        return std::string_view(reinterpret_cast<const char*>(stream->buf) + current_index(), stream->parser->implementation->structural_indexes[++cur_struct_index] - current_index() - 1);
+    }
+    cur_struct_index++;
+  }
+
+  while (cur_struct_index <= static_cast<int64_t>(stream->parser->implementation->n_structural_indexes)) {
+    switch (stream->buf[stream->batch_start + stream->parser->implementation->structural_indexes[cur_struct_index]]) {
+      case '{': case '[':
+        depth++;
+        break;
+      case '}': case ']':
+        depth--;
+        break;
+    }
+    if (depth == 0) { break; }
+    cur_struct_index++;
+  }
+
+  return std::string_view(reinterpret_cast<const char*>(stream->buf) + current_index(), stream->parser->implementation->structural_indexes[cur_struct_index] - current_index() + stream->batch_start + 1);;
+}
+
+inline error_code document_stream::iterator::error() const noexcept {
+  return stream->error;
+}
+
+#ifdef SIMDJSON_THREADS_ENABLED
+
+inline void document_stream::load_from_stage1_thread() noexcept {
+  worker->finish();
+  // Swap to the parser that was loaded up in the thread. Make sure the parser has
+  // enough memory to swap to, as well.
+  std::swap(stage1_thread_parser,*parser);
+  error = stage1_thread_error;
+  if (error) { return; }
+
+  // If there's anything left, start the stage 1 thread!
+  if (next_batch_start() < len) {
+    start_stage1_thread();
+  }
+}
+
+inline void document_stream::start_stage1_thread() noexcept {
+  // we call the thread on a lambda that will update
+  // this->stage1_thread_error
+  // there is only one thread that may write to this value
+  // TODO this is NOT exception-safe.
+  this->stage1_thread_error = UNINITIALIZED; // In case something goes wrong, make sure it's an error
+  size_t _next_batch_start = this->next_batch_start();
+
+  worker->run(this, & this->stage1_thread_parser, _next_batch_start);
+}
+
+#endif // SIMDJSON_THREADS_ENABLED
+
+} // namespace ondemand
+} // namespace SIMDJSON_BUILTIN_IMPLEMENTATION
+} // namespace simdjson
+
+namespace simdjson {
+
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_stream>::simdjson_result(
+  error_code error
+) noexcept :
+    implementation_simdjson_result_base<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_stream>(error)
+{
+}
+simdjson_really_inline simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_stream>::simdjson_result(
+  SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_stream &&value
+) noexcept :
+    implementation_simdjson_result_base<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_stream>(
+      std::forward<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_stream>(value)
+    )
+{
+}
+
+}
+/* end file include/simdjson/generic/ondemand/document_stream-inl.h */
+/* begin file include/simdjson/generic/ondemand/serialization-inl.h */
+
+
+namespace simdjson {
+
+inline std::string_view trim(const std::string_view str) noexcept {
+  // We can almost surely do better by rolling our own find_first_not_of function.
+  size_t first = str.find_first_not_of(" \t\n\r");
+  // If we have the empty string (just white space), then no trimming is possible, and
+  // we return the empty string_view.
+  if (std::string_view::npos == first) { return std::string_view(); }
+  size_t last = str.find_last_not_of(" \t\n\r");
+  return str.substr(first, (last - first + 1));
+}
+
+
+inline simdjson_result<std::string_view> to_json_string(SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document& x) noexcept {
+  std::string_view v;
+  auto error = x.raw_json().get(v);
+  if(error) {return error; }
+  return trim(v);
+}
+
+inline simdjson_result<std::string_view> to_json_string(SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference& x) noexcept {
+  std::string_view v;
+  auto error = x.raw_json().get(v);
+  if(error) {return error; }
+  return trim(v);
+}
+
+inline simdjson_result<std::string_view> to_json_string(SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value& x) noexcept {
+  /**
+   * If we somehow receive a value that has already been consumed,
+   * then the following code could be in trouble. E.g., we create
+   * an array as needed, but if an array was already created, then
+   * it could be bad.
+   */
+  using namespace SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand;
+  SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::json_type t;
+  auto error = x.type().get(t);
+  if(error != SUCCESS) { return error; }
+  switch (t)
+  {
+    case json_type::array:
+    {
+      SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array array;
+      error = x.get_array().get(array);
+      if(error) { return error; }
+      return to_json_string(array);
+    }
+    case json_type::object:
+    {
+      SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object object;
+      error = x.get_object().get(object);
+      if(error) { return error; }
+      return to_json_string(object);
+    }
+    default:
+      return trim(x.raw_json_token());
+  }
+}
+
+inline simdjson_result<std::string_view> to_json_string(SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object& x) noexcept {
+  std::string_view v;
+  auto error = x.raw_json().get(v);
+  if(error) {return error; }
+  return trim(v);
+}
+
+inline simdjson_result<std::string_view> to_json_string(SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array& x) noexcept {
+  std::string_view v;
+  auto error = x.raw_json().get(v);
+  if(error) {return error; }
+  return trim(v);
+}
+
+inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document> x) {
+  if (x.error()) { return x.error(); }
+  return to_json_string(x.value_unsafe());
+}
+
+inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference> x) {
+  if (x.error()) { return x.error(); }
+  return to_json_string(x.value_unsafe());
+}
+
+inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> x) {
+  if (x.error()) { return x.error(); }
+  return to_json_string(x.value_unsafe());
+}
+
+inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object> x) {
+  if (x.error()) { return x.error(); }
+  return to_json_string(x.value_unsafe());
+}
+
+inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array> x) {
+  if (x.error()) { return x.error(); }
+  return to_json_string(x.value_unsafe());
+}
+} // namespace simdjson
+
+
+#if SIMDJSON_EXCEPTIONS
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value x) {
+  std::string_view v;
+  auto error = simdjson::to_json_string(x).get(v);
+  if(error == simdjson::SUCCESS) {
+    return (out << v);
+  } else {
+    throw simdjson::simdjson_error(error);
+  }
+}
+inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value> x) {
+  if (x.error()) { throw simdjson::simdjson_error(x.error()); }
+  return (out << x.value());
+}
+#else
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::value x) {
+  std::string_view v;
+  auto error = simdjson::to_json_string(x).get(v);
+  if(error == simdjson::SUCCESS) {
+    return (out << v);
+  } else {
+    return (out << error);
+  }
+}
+#endif
+
+#if SIMDJSON_EXCEPTIONS
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array value) {
+  std::string_view v;
+  auto error = simdjson::to_json_string(value).get(v);
+  if(error == simdjson::SUCCESS) {
+    return (out << v);
+  } else {
+    throw simdjson::simdjson_error(error);
+  }
+}
+inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array> x) {
+  if (x.error()) { throw simdjson::simdjson_error(x.error()); }
+  return (out << x.value());
+}
+#else
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::array value) {
+  std::string_view v;
+  auto error = simdjson::to_json_string(value).get(v);
+  if(error == simdjson::SUCCESS) {
+    return (out << v);
+  } else {
+    return (out << error);
+  }
+}
+#endif
+
+#if SIMDJSON_EXCEPTIONS
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document& value)  {
+  std::string_view v;
+  auto error = simdjson::to_json_string(value).get(v);
+  if(error == simdjson::SUCCESS) {
+    return (out << v);
+  } else {
+    throw simdjson::simdjson_error(error);
+  }
+}
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference& value)  {
+  std::string_view v;
+  auto error = simdjson::to_json_string(value).get(v);
+  if(error == simdjson::SUCCESS) {
+    return (out << v);
+  } else {
+    throw simdjson::simdjson_error(error);
+  }
+}
+inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document>&& x) {
+  if (x.error()) { throw simdjson::simdjson_error(x.error()); }
+  return (out << x.value());
+}
+inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document_reference>&& x) {
+  if (x.error()) { throw simdjson::simdjson_error(x.error()); }
+  return (out << x.value());
+}
+#else
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::document& value)  {
+  std::string_view v;
+  auto error = simdjson::to_json_string(value).get(v);
+  if(error == simdjson::SUCCESS) {
+    return (out << v);
+  } else {
+    return (out << error);
+  }
+}
+#endif
+
+#if SIMDJSON_EXCEPTIONS
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object value) {
+  std::string_view v;
+  auto error = simdjson::to_json_string(value).get(v);
+  if(error == simdjson::SUCCESS) {
+    return (out << v);
+  } else {
+    throw simdjson::simdjson_error(error);
+  }
+}
+inline std::ostream& operator<<(std::ostream& out,  simdjson::simdjson_result<simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object> x) {
+  if (x.error()) { throw  simdjson::simdjson_error(x.error()); }
+  return (out << x.value());
+}
+#else
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::object value) {
+  std::string_view v;
+  auto error = simdjson::to_json_string(value).get(v);
+  if(error == simdjson::SUCCESS) {
+    return (out << v);
+  } else {
+    return (out << error);
+  }
+}
+#endif
+/* end file include/simdjson/generic/ondemand/serialization-inl.h */
 /* end file include/simdjson/generic/ondemand-inl.h */
 
 


### PR DESCRIPTION
I have begun to update RcppSimdJson to On Demand. The main complication that I have seen is that On Demand does not have specific JSON type for numbers. It labels double, signed integers and unsigned integers as `json_type::number`. To work around this, I have created a enum class `complete_json_type` that can identify the type of a `json_type::number`. This might not be an optimal solution, but it can serve as a prototype. I have not yet worked on matrix and data frame deserialization, only on scalar and vector deserialization, but there might still be typos and broken things in those files. 